### PR TITLE
fix: update setup-rag tests to match ragling refactor

### DIFF
--- a/plugins/dev-workflow-toolkit/tests/test-integration.sh
+++ b/plugins/dev-workflow-toolkit/tests/test-integration.sh
@@ -187,14 +187,14 @@ echo "Validating MCP configuration patterns..."
 setup_rag_skill="$SKILLS_DIR/setup-rag/SKILL.md"
 
 if [ -f "$setup_rag_skill" ]; then
-    # Check for required environment variables
-    required_vars=("LOCAL_RAG_PROJECT" "LOCAL_RAG_DATA_DIR" "LOCAL_RAG_WATCH" "LOCAL_RAG_ROOT")
+    # Check for ragling configuration artifacts
+    required_terms=("ragling init" "mcpServers.ragling" ".ragling" "ragling.json")
 
-    for var in "${required_vars[@]}"; do
-        if grep -q "$var" "$setup_rag_skill"; then
-            pass "MCP config includes: $var"
+    for term in "${required_terms[@]}"; do
+        if grep -q "$term" "$setup_rag_skill"; then
+            pass "MCP config includes: $term"
         else
-            fail "MCP config missing: $var"
+            fail "MCP config missing: $term"
         fi
     done
 

--- a/plugins/dev-workflow-toolkit/tests/test-setup-rag.sh
+++ b/plugins/dev-workflow-toolkit/tests/test-setup-rag.sh
@@ -28,10 +28,10 @@ fi
 
 # Test 2: Skill contains prerequisite check
 tests=$((tests + 1))
-if grep -q "which local-rag" "$SKILL_FILE"; then
-    echo -e "${GREEN}✓${NC} Contains prerequisite check for local-rag"
+if grep -q "which uv" "$SKILL_FILE"; then
+    echo -e "${GREEN}✓${NC} Contains prerequisite check for uv"
 else
-    echo -e "${RED}✗${NC} Missing prerequisite check for local-rag"
+    echo -e "${RED}✗${NC} Missing prerequisite check for uv"
     failures=$((failures + 1))
 fi
 
@@ -44,20 +44,20 @@ else
     failures=$((failures + 1))
 fi
 
-# Test 4: Skill includes required environment variables
-required_env_vars=(
-    "LOCAL_RAG_PROJECT"
-    "LOCAL_RAG_DATA_DIR"
-    "LOCAL_RAG_WATCH"
-    "LOCAL_RAG_ROOT"
+# Test 4: Skill includes ragling configuration artifacts
+required_artifacts=(
+    "ragling init"
+    "ragling.json"
+    ".ragling"
+    "mcpServers.ragling"
 )
 
-for env_var in "${required_env_vars[@]}"; do
+for artifact in "${required_artifacts[@]}"; do
     tests=$((tests + 1))
-    if grep -q "$env_var" "$SKILL_FILE"; then
-        echo -e "${GREEN}✓${NC} Includes env var: $env_var"
+    if grep -q "$artifact" "$SKILL_FILE"; then
+        echo -e "${GREEN}✓${NC} Includes config artifact: $artifact"
     else
-        echo -e "${RED}✗${NC} Missing env var: $env_var"
+        echo -e "${RED}✗${NC} Missing config artifact: $artifact"
         failures=$((failures + 1))
     fi
 done
@@ -88,18 +88,6 @@ else
     echo -e "${RED}✗${NC} Missing project isolation concept"
     failures=$((failures + 1))
 fi
-
-# Test 8: Validate JSON structure in skill is valid
-tests=$((tests + 1))
-# Extract JSON block from skill and validate structure
-json_block=$(sed -n '/```json/,/```/p' "$SKILL_FILE" | sed '1d;$d' | head -20)
-if echo "$json_block" | grep -q "mcpServers" && echo "$json_block" | grep -q "local-rag"; then
-    echo -e "${GREEN}✓${NC} JSON configuration structure is valid"
-else
-    echo -e "${RED}✗${NC} JSON configuration structure invalid or missing"
-    failures=$((failures + 1))
-fi
-
 echo ""
 echo "Tests: $tests, Failures: $failures"
 


### PR DESCRIPTION
## Summary
- Updated `test-setup-rag.sh` to check for ragling prerequisites (`which uv`), config artifacts (`ragling init`, `ragling.json`, `.ragling`, `mcpServers.ragling`), and removed redundant Test #8
- Updated `test-integration.sh` MCP config section to validate ragling-specific terms instead of obsolete `LOCAL_RAG_*` env vars
- All 75 tests passing, 0 failures

## Beads
**Issue:** my-claude-plugins-5l2 (bug: test failures)

## Test Plan
- [x] `bash plugins/dev-workflow-toolkit/tests/run-all.sh` exits 0
- [x] No existing passing tests broken

<details><summary>Implementation Plan</summary>

**Root cause:** The setup-rag skill was refactored from `local-rag` to `ragling` (commit a8d4d45), but tests still asserted the old approach — checking for `LOCAL_RAG_*` env vars, `which local-rag`, and a JSON config block that no longer exists.

**Fix:** Updated test assertions to match the current ragling-based skill. Removed one redundant test (Test #8 duplicated Test #4's `mcpServers.ragling` check). Aligned integration test term specificity with unit test.

</details>

Closes #30