### PR TITLE
feat: Langfuse full data capture (v1.8.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,7 +61,7 @@
     {
       "name": "dev-workflow-toolkit",
       "description": "Development workflow skills: brainstorming, planning, execution, debugging, testing, code review, and project scaffolding",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "source": "./plugins/dev-workflow-toolkit"
     }

--- a/plugins/dev-workflow-toolkit/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow-toolkit",
   "description": "Development workflow skills: brainstorming, planning, execution, debugging, testing, code review, project scaffolding, retrospective, and automated quality gates",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "author": { "name": "stvhay" },
   "license": "Apache-2.0"
 }

--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,6 +3,33 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
+## v1.8.0
+
+### Langfuse tracing: full data capture
+
+Generations now include user prompts as input (previously only assistant
+output was shipped). Timestamps from transcript JSONL are used for
+`start_time`/`end_time` on generation observations, giving real LLM
+latency in Langfuse. Session metadata now includes `cwd`,
+`permission_mode`, and `cache_hit_rate`. Subagent spans capture
+`last_assistant_message` as output.
+
+## v1.7.1
+
+Fix: use `setsid` to create a new process session so the background
+Langfuse process survives SessionEnd process group kill.
+
+## v1.7.0
+
+### Async hook execution and error reporting
+
+All Langfuse SDK work now runs fully backgrounded — hooks never block
+Claude Code. Sentinel-based error reporting writes per-call error files
+and touches `~/.cache/langfuse-hook/error-flag`; the SessionStart health
+check is a single file-exists test with zero cost on the happy path.
+SDK delivery failures (silent by default) are detected via stderr
+capture with `logging.basicConfig(force=True)`.
+
 ## v1.6.6
 
 Use uv instead of python3 -m venv for bootstrap. Faster and avoids

--- a/plugins/dev-workflow-toolkit/hooks/langfuse-trace.py
+++ b/plugins/dev-workflow-toolkit/hooks/langfuse-trace.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Route SDK/OTel warnings to stderr so the shell wrapper can detect failures
@@ -160,20 +161,75 @@ def get_trace_context(session_id):
 # -- Shipping observations --
 
 
+def parse_timestamp(ts_str):
+    """Parse an ISO 8601 timestamp string to a datetime object."""
+    if not ts_str:
+        return None
+    try:
+        # Handle "2026-03-11T12:43:40.155Z" format
+        return datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def extract_user_input(content):
+    """Extract text from a user message's content (string or content blocks)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        texts = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    texts.append(block.get("text", ""))
+                elif block.get("type") == "tool_result":
+                    # Skip tool results — they're tracked as tool observations
+                    continue
+        return "\n".join(texts) if texts else None
+    return None
+
+
+def read_all_messages(transcript_path):
+    """Read all messages from a transcript JSONL file in order."""
+    messages = []
+    path = Path(transcript_path)
+    if not path.exists():
+        return messages
+    with open(path) as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if obj.get("type") in ("user", "assistant"):
+                messages.append(obj)
+    return messages
+
+
 def ship_transcript_data(client, trace_id, transcript_path, sent_ids,
                          parent_span_id=None):
     """Ship new generations and tool observations from a transcript.
 
     Returns the updated set of sent request IDs.
     """
-    assistant_msgs = read_transcript_messages(transcript_path, "assistant")
+    all_msgs = read_all_messages(transcript_path)
     tool_results = get_tool_results(transcript_path)
 
     trace_ctx = {"trace_id": trace_id}
     if parent_span_id:
         trace_ctx["parent_span_id"] = parent_span_id
 
-    for msg in assistant_msgs:
+    # Track preceding user message for each assistant message
+    last_user_input = None
+    last_user_ts = None
+    for msg in all_msgs:
+        if msg.get("type") == "user":
+            user_content = msg.get("message", {}).get("content", "")
+            last_user_input = extract_user_input(user_content)
+            last_user_ts = parse_timestamp(msg.get("timestamp"))
+            continue
+
+        # Assistant message
         request_id = msg.get("requestId")
         if not request_id or request_id in sent_ids:
             continue
@@ -181,16 +237,18 @@ def ship_transcript_data(client, trace_id, transcript_path, sent_ids,
         api_msg = msg.get("message", {})
         usage = api_msg.get("usage", {})
         content_blocks = api_msg.get("content", [])
+        assistant_ts = parse_timestamp(msg.get("timestamp"))
 
-        # Ship generation
-        gen = client.start_observation(
-            trace_context=trace_ctx,
-            name="llm-call",
-            as_type="generation",
-            model=api_msg.get("model", "unknown"),
-            usage_details=extract_usage(usage),
-            output=extract_text_output(content_blocks),
-            metadata={
+        # Ship generation with user input, assistant output, and timing
+        gen_kwargs = {
+            "trace_context": trace_ctx,
+            "name": "llm-call",
+            "as_type": "generation",
+            "model": api_msg.get("model", "unknown"),
+            "usage_details": extract_usage(usage),
+            "input": last_user_input,
+            "output": extract_text_output(content_blocks),
+            "metadata": {
                 "request_id": request_id,
                 "stop_reason": api_msg.get("stop_reason"),
                 "service_tier": usage.get("service_tier"),
@@ -198,7 +256,14 @@ def ship_transcript_data(client, trace_id, transcript_path, sent_ids,
                     "cache_creation_input_tokens", 0
                 ),
             },
-        )
+        }
+        # Use user message timestamp as start, assistant timestamp as end
+        if last_user_ts:
+            gen_kwargs["start_time"] = last_user_ts
+        if assistant_ts:
+            gen_kwargs["end_time"] = assistant_ts
+
+        gen = client.start_observation(**gen_kwargs)
         gen.end()
 
         # Ship tool calls
@@ -238,12 +303,15 @@ def handle_session_start(client, hook_input):
     with propagate_attributes(
         trace_name=f"claude-code-{source}",
         session_id=ctx["git_branch"] or session_id,
-        tags=build_tags(ctx["source_project"], model, ctx["git_branch"]),
+        tags=build_tags(ctx["source_project"], model, ctx["git_branch"],
+                        hook_input.get("permission_mode", "")),
         metadata={
             "source_project": ctx["source_project"],
             "model": model,
             "git_branch": ctx["git_branch"],
             "source": source,
+            "cwd": hook_input.get("cwd", ""),
+            "permission_mode": hook_input.get("permission_mode", ""),
             "claude_version": hook_input.get("version", ""),
         },
     ):
@@ -277,10 +345,13 @@ def handle_post_tool_use(client, hook_input):
         with propagate_attributes(
             trace_name="claude-code-session",
             session_id=ctx["git_branch"] or session_id,
-            tags=build_tags(ctx["source_project"], ctx["git_branch"]),
+            tags=build_tags(ctx["source_project"], ctx["git_branch"],
+                            hook_input.get("permission_mode", "")),
             metadata={
                 "source_project": ctx["source_project"],
                 "git_branch": ctx["git_branch"],
+                "cwd": hook_input.get("cwd", ""),
+                "permission_mode": hook_input.get("permission_mode", ""),
             },
         ):
             obs = client.start_observation(
@@ -311,11 +382,17 @@ def handle_subagent_stop(client, hook_input):
     sent_ids = set(state.get("sent_request_ids", []))
 
     # Create parent agent span
+    last_message = hook_input.get("last_assistant_message", "")
     agent_span = client.start_observation(
         trace_context={"trace_id": trace_id},
         name=f"subagent-{agent_type}",
         as_type="agent",
-        metadata={"agent_id": agent_id, "agent_type": agent_type},
+        output=last_message or None,
+        metadata={
+            "agent_id": agent_id,
+            "agent_type": agent_type,
+            "stop_hook_active": hook_input.get("stop_hook_active", False),
+        },
     )
 
     sent_ids = ship_transcript_data(
@@ -353,6 +430,9 @@ def handle_session_end(client, hook_input):
 
     # Use observation-level metadata (supports int values) instead of
     # propagate_attributes metadata (requires string values per SDK validation)
+    total_input = totals["input"] + totals["cache_read"] + totals["cache_create"]
+    cache_hit_rate = (totals["cache_read"] / total_input) if total_input > 0 else 0.0
+
     obs = client.start_observation(
         trace_context={"trace_id": trace_id},
         name="session-summary",
@@ -362,8 +442,11 @@ def handle_session_end(client, hook_input):
             "total_output_tokens": totals["output"],
             "total_cache_read_tokens": totals["cache_read"],
             "total_cache_creation_tokens": totals["cache_create"],
+            "cache_hit_rate": round(cache_hit_rate, 3),
             "total_api_calls": len(state.get("sent_request_ids", [])),
             "reason": hook_input.get("reason", "unknown"),
+            "cwd": hook_input.get("cwd", ""),
+            "permission_mode": hook_input.get("permission_mode", ""),
         },
     )
     obs.end()

--- a/plugins/dev-workflow-toolkit/hooks/test_langfuse_trace.py
+++ b/plugins/dev-workflow-toolkit/hooks/test_langfuse_trace.py
@@ -14,6 +14,7 @@ _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 
 # Bind module-level functions
+parse_timestamp = _mod.parse_timestamp
 is_configured = _mod.is_configured
 get_source_project = _mod.get_source_project
 get_git_branch = _mod.get_git_branch
@@ -21,7 +22,9 @@ build_tags = _mod.build_tags
 record_error = _mod.record_error
 extract_usage = _mod.extract_usage
 extract_text_output = _mod.extract_text_output
+extract_user_input = _mod.extract_user_input
 read_transcript_messages = _mod.read_transcript_messages
+read_all_messages = _mod.read_all_messages
 get_tool_results = _mod.get_tool_results
 get_state_dir = _mod.get_state_dir
 get_state_path = _mod.get_state_path
@@ -133,6 +136,81 @@ class TestBuildTags:
 
     def test_all_present(self):
         assert build_tags("x", "y") == ["x", "y"]
+
+
+# -- parse_timestamp --
+
+
+class TestParseTimestamp:
+    def test_iso_with_z(self):
+        dt = parse_timestamp("2026-03-11T12:43:40.155Z")
+        assert dt is not None
+        assert dt.year == 2026
+        assert dt.month == 3
+        assert dt.second == 40
+
+    def test_none(self):
+        assert parse_timestamp(None) is None
+
+    def test_empty(self):
+        assert parse_timestamp("") is None
+
+    def test_invalid(self):
+        assert parse_timestamp("not-a-date") is None
+
+
+# -- extract_user_input --
+
+
+class TestExtractUserInput:
+    def test_string_content(self):
+        assert extract_user_input("hello world") == "hello world"
+
+    def test_text_blocks(self):
+        content = [
+            {"type": "text", "text": "What is this?"},
+            {"type": "text", "text": "Tell me more."},
+        ]
+        assert extract_user_input(content) == "What is this?\nTell me more."
+
+    def test_skips_tool_results(self):
+        content = [
+            {"type": "tool_result", "tool_use_id": "t1", "content": "ok"},
+            {"type": "text", "text": "Now do X"},
+        ]
+        assert extract_user_input(content) == "Now do X"
+
+    def test_only_tool_results_returns_none(self):
+        content = [
+            {"type": "tool_result", "tool_use_id": "t1", "content": "ok"},
+        ]
+        assert extract_user_input(content) is None
+
+    def test_empty_list(self):
+        assert extract_user_input([]) is None
+
+    def test_none(self):
+        assert extract_user_input(None) is None
+
+
+# -- read_all_messages --
+
+
+class TestReadAllMessages:
+    def test_reads_both_types_in_order(self, tmp_path):
+        path = tmp_path / "transcript.jsonl"
+        write_transcript(path, [
+            make_user_msg(),
+            make_assistant_msg("req1"),
+            make_user_msg([make_tool_result("t1")]),
+            make_assistant_msg("req2"),
+        ])
+        msgs = read_all_messages(str(path))
+        assert len(msgs) == 4
+        assert [m["type"] for m in msgs] == ["user", "assistant", "user", "assistant"]
+
+    def test_missing_file(self):
+        assert read_all_messages("/nonexistent/path.jsonl") == []
 
 
 # -- extract_usage --
@@ -282,6 +360,65 @@ class TestShipTranscriptData:
         assert calls[1].kwargs["as_type"] == "tool"
         assert calls[1].kwargs["name"] == "Bash"
 
+    def test_includes_user_input_on_generation(self, tmp_path):
+        path = tmp_path / "transcript.jsonl"
+        write_transcript(path, [
+            make_user_msg([{"type": "text", "text": "What is 2+2?"}]),
+            make_assistant_msg("req1", text="4"),
+        ])
+
+        client = MagicMock()
+        mock_obs = MagicMock()
+        client.start_observation.return_value = mock_obs
+
+        ship_transcript_data(client, "trace123", str(path), set())
+
+        gen_call = client.start_observation.call_args_list[0]
+        assert gen_call.kwargs["input"] == "What is 2+2?"
+        assert gen_call.kwargs["output"] == "4"
+
+    def test_ships_timestamps_on_generation(self, tmp_path):
+        """User timestamp → start_time, assistant timestamp → end_time."""
+        path = tmp_path / "transcript.jsonl"
+        msgs = [
+            {"type": "user", "timestamp": "2026-03-11T12:00:00.000Z",
+             "message": {"content": "hi"}},
+            {"type": "assistant", "requestId": "req1",
+             "timestamp": "2026-03-11T12:00:05.500Z",
+             "message": {"model": "claude-opus-4-6", "content": [{"type": "text", "text": "hello"}],
+                         "usage": {"input_tokens": 10, "output_tokens": 5},
+                         "stop_reason": "end_turn"}},
+        ]
+        write_transcript(path, msgs)
+
+        client = MagicMock()
+        mock_obs = MagicMock()
+        client.start_observation.return_value = mock_obs
+
+        ship_transcript_data(client, "trace123", str(path), set())
+
+        gen_call = client.start_observation.call_args_list[0]
+        assert gen_call.kwargs["start_time"].second == 0
+        assert gen_call.kwargs["end_time"].second == 5
+
+    def test_user_string_content_as_input(self, tmp_path):
+        """User messages with plain string content are captured."""
+        path = tmp_path / "transcript.jsonl"
+        msgs = [
+            {"type": "user", "message": {"content": "plain string prompt"}},
+            make_assistant_msg("req1", text="response"),
+        ]
+        write_transcript(path, msgs)
+
+        client = MagicMock()
+        mock_obs = MagicMock()
+        client.start_observation.return_value = mock_obs
+
+        ship_transcript_data(client, "trace123", str(path), set())
+
+        gen_call = client.start_observation.call_args_list[0]
+        assert gen_call.kwargs["input"] == "plain string prompt"
+
     def test_skips_already_sent(self, tmp_path):
         path = tmp_path / "transcript.jsonl"
         write_transcript(path, [make_assistant_msg("req1")])
@@ -349,6 +486,31 @@ class TestHandleSubagentStop:
         # The generation should use agent_obs.id as parent
         gen_call = client.start_observation.call_args_list[1]
         assert gen_call.kwargs["trace_context"]["parent_span_id"] == "abc123def456"
+
+    def test_ships_last_assistant_message(self, tmp_path):
+        path = tmp_path / "transcript.jsonl"
+        write_transcript(path, [make_assistant_msg("req1")])
+
+        client = MagicMock()
+        agent_obs = MagicMock()
+        agent_obs.id = "abc123"
+        gen_obs = MagicMock()
+        client.start_observation.side_effect = [agent_obs, gen_obs]
+
+        with patch.object(_mod, "load_state",
+                          return_value={"trace_id": "t1", "sent_request_ids": []}), \
+             patch.object(_mod, "save_state"):
+            handle_subagent_stop(client, {
+                "session_id": "sess1",
+                "agent_id": "a1",
+                "agent_type": "Explore",
+                "agent_transcript_path": str(path),
+                "last_assistant_message": "Found 3 files matching pattern.",
+            })
+
+        agent_call = client.start_observation.call_args_list[0]
+        assert agent_call.kwargs["output"] == "Found 3 files matching pattern."
+        assert agent_call.kwargs["metadata"]["stop_hook_active"] is False
 
 
 class TestHandleSessionEnd:

--- a/plugins/dev-workflow-toolkit/pyproject.toml
+++ b/plugins/dev-workflow-toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dev-workflow-toolkit"
-version = "1.7.1"
+version = "1.8.0"
 description = "Development workflow skills for Claude Code"
 requires-python = ">=3.13"
 dependencies = [

--- a/plugins/dev-workflow-toolkit/uv.lock
+++ b/plugins/dev-workflow-toolkit/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "dev-workflow-toolkit"
-version = "1.5.0"
+version = "1.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "markdown-it-py" },


### PR DESCRIPTION
## Summary
- Ship user prompts as `input` on generation observations (previously only assistant output was captured)
- Use transcript timestamps for `start_time`/`end_time` on generations — real LLM latency visible in Langfuse
- Add `cwd`, `permission_mode`, `cache_hit_rate` to session metadata
- Capture `last_assistant_message` as output on subagent spans
- Configure Langfuse model definitions with `inputCached` pricing (10x discount) for all three Claude models
- Add CHANGELOG entries for v1.7.0, v1.7.1, v1.8.0 (fixes CI failure)

## Test plan
- [x] 50 unit tests passing (up from 34)
- [x] 7 integration tests passing
- [x] CI changelog test passes locally
- [ ] E2E: verify user prompts appear in Langfuse generation input
- [ ] E2E: verify timestamps show latency in Langfuse UI
- [ ] E2E: verify cost calculation uses cache pricing

Closes #39 Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)