### PR TITLE
fix: adapt langfuse hook to SDK v4 start_observation API

### DIFF
--- a/plugins/dev-workflow-toolkit/hooks/langfuse-trace.py
+++ b/plugins/dev-workflow-toolkit/hooks/langfuse-trace.py
@@ -257,14 +257,16 @@ def ship_transcript_data(client, trace_id, transcript_path, sent_ids,
                 ),
             },
         }
-        # Use user message timestamp as start, assistant timestamp as end
+        # SDK v4 start_observation doesn't accept start_time/end_time.
+        # Store timestamps in metadata; pass end_time (as epoch ns) to .end().
         if last_user_ts:
-            gen_kwargs["start_time"] = last_user_ts
+            gen_kwargs["metadata"]["start_time"] = last_user_ts.isoformat()
         if assistant_ts:
-            gen_kwargs["end_time"] = assistant_ts
+            gen_kwargs["metadata"]["end_time"] = assistant_ts.isoformat()
 
         gen = client.start_observation(**gen_kwargs)
-        gen.end()
+        end_ns = int(assistant_ts.timestamp() * 1e9) if assistant_ts else None
+        gen.end(end_time=end_ns)
 
         # Ship tool calls
         for block in content_blocks:

--- a/plugins/dev-workflow-toolkit/hooks/test_langfuse_trace.py
+++ b/plugins/dev-workflow-toolkit/hooks/test_langfuse_trace.py
@@ -378,7 +378,7 @@ class TestShipTranscriptData:
         assert gen_call.kwargs["output"] == "4"
 
     def test_ships_timestamps_on_generation(self, tmp_path):
-        """User timestamp → start_time, assistant timestamp → end_time."""
+        """User timestamp → metadata start_time, assistant timestamp → end() + metadata."""
         path = tmp_path / "transcript.jsonl"
         msgs = [
             {"type": "user", "timestamp": "2026-03-11T12:00:00.000Z",
@@ -398,8 +398,15 @@ class TestShipTranscriptData:
         ship_transcript_data(client, "trace123", str(path), set())
 
         gen_call = client.start_observation.call_args_list[0]
-        assert gen_call.kwargs["start_time"].second == 0
-        assert gen_call.kwargs["end_time"].second == 5
+        # SDK v4: timestamps stored in metadata, end_time passed to .end()
+        metadata = gen_call.kwargs["metadata"]
+        assert "2026-03-11T12:00:00" in metadata["start_time"]
+        assert "2026-03-11T12:00:05" in metadata["end_time"]
+        # end_time passed as nanoseconds to .end()
+        mock_obs.end.assert_called_once()
+        end_ns = mock_obs.end.call_args.kwargs.get("end_time")
+        assert end_ns is not None
+        assert end_ns > 0
 
     def test_user_string_content_as_input(self, tmp_path):
         """User messages with plain string content are captured."""


### PR DESCRIPTION
## Summary
- Langfuse SDK v4.0.0 removed `start_time`/`end_time` from `start_observation()`, breaking all telemetry shipping with `got an unexpected keyword argument 'start_time'`
- Moves timestamps into observation metadata (still queryable) and passes `end_time` as epoch nanoseconds to `.end()`
- Updates test to match new behavior; all 58 tests pass

## Test plan
- [x] 50 unit tests pass
- [x] 8 shell integration tests pass
- [x] Error sentinel cleared, next hook invocation should ship successfully

Fixes #39 (unblocks Phase 1 data collection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)