### PR TITLE
fix: ensure-statusline.sh wrong binary name in tarball

### DIFF
--- a/plugins/dev-workflow-toolkit/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow-toolkit",
   "description": "Development workflow skills: brainstorming, planning, execution, debugging, testing, code review, project scaffolding, retrospective, and automated quality gates",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": {
     "name": "stvhay"
   },

--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,6 +3,12 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
+## v1.12.1
+
+Fix: `ensure-statusline.sh` looked for binary named `claude-statusline` in
+the release tarball, but the actual binary is named `statusline`. Hook failed
+on fresh installs.
+
 ## v1.12.0
 
 ### Added

--- a/plugins/dev-workflow-toolkit/hooks/ensure-statusline.sh
+++ b/plugins/dev-workflow-toolkit/hooks/ensure-statusline.sh
@@ -93,7 +93,7 @@ download_and_install() {
 
     # Find the binary in extracted files
     local extracted_binary
-    extracted_binary="$(find "$tmpdir" -name 'claude-statusline' -type f ! -name '*.tar.gz' | head -1)"
+    extracted_binary="$(find "$tmpdir" -name 'statusline' -type f ! -name '*.tar.gz' | head -1)"
     if [ -z "$extracted_binary" ]; then
         warn "binary not found in tarball"
         return 1

--- a/plugins/dev-workflow-toolkit/pyproject.toml
+++ b/plugins/dev-workflow-toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dev-workflow-toolkit"
-version = "1.12.0"
+version = "1.12.1"
 description = "Development workflow skills for Claude Code"
 requires-python = ">=3.13"
 dependencies = [


### PR DESCRIPTION
## Summary
- Fix `find` command in `ensure-statusline.sh` to look for `statusline` instead of `claude-statusline` — matching the actual binary name in release tarballs
- Patch bump to v1.12.1

## Test plan
- [x] Verified manually: `tar xzf` of v0.3.0 release contains `statusline`, not `claude-statusline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #87