### PR TITLE
fix: switch to GitHub ruleset with bot bypass for release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             # Check if plugin has source file changes (exclude docs, config, locks)
             SOURCE_CHANGES=$(git diff --name-only "$BASE_SHA"...HEAD -- "$plugin_dir" \
               | grep -v -E '\.(md|yml|yaml)$' \
-              | grep -v -E '(uv\.lock|plugin\.json)$' \
+              | grep -v -E '(uv\.lock|plugin\.json|pyproject\.toml)$' \
               || true)
 
             if [ -z "$SOURCE_CHANGES" ]; then

--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -8,6 +8,7 @@ read this file and apply retroactive actions marked with **ACTION**.
 
 ### Fixed
 - Brainstorming auto-creates worktree when on main/master instead of asking (#97)
+- Release workflow blocked by branch protection — switch from classic branch protection to ruleset with bot bypass (#104)
 
 ### Changed
 - **Version bumping is now CI-driven.** Branches write `## Unreleased` changelog


### PR DESCRIPTION
## Summary

- Replaced classic branch protection on main with a GitHub ruleset that has Maintain role bypass, allowing the release workflow's `GITHUB_TOKEN` to push version bump commits directly
- Excluded `pyproject.toml` from CI version-check source change detection (it's a version file, not source code)
- Enabled auto-merge on repo settings
- Classic branch protection already removed and ruleset already created via API

## What changed (settings, not just code)

The branch protection change was applied immediately via the GitHub API:
- **Removed:** Classic branch protection (required `test` status check)
- **Added:** Repository ruleset "main protection" with `test` required status check + Maintain role bypass

## Risk

If the Maintain role bypass doesn't cover `GITHUB_TOKEN` pushes from Actions, the release workflow will still fail. In that case, we'd need a PAT secret or GitHub App. This PR is the test — if CI passes and the release workflow succeeds after merge, we're good.

## Test Plan
- [x] 291 tests pass
- [ ] After merge: release workflow pushes version bump to main successfully

Closes #104