### PR TITLE
fix: use GitHub App token for release workflow push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,16 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -8,7 +8,7 @@ read this file and apply retroactive actions marked with **ACTION**.
 
 ### Fixed
 - Brainstorming auto-creates worktree when on main/master instead of asking (#97)
-- Release workflow blocked by branch protection — switch from classic branch protection to ruleset with bot bypass (#104)
+- Release workflow blocked by branch protection — use GitHub App token + ruleset bypass for version bump push (#104)
 
 ### Changed
 - **Version bumping is now CI-driven.** Branches write `## Unreleased` changelog


### PR DESCRIPTION
## Summary

- Release workflow uses `actions/create-github-app-token` to get an app token that can bypass the ruleset
- Classic branch protection replaced with GitHub ruleset (done via API, already applied)
- App `my-claude-plugins-release` added to ruleset bypass list as Integration actor
- Excluded `pyproject.toml` from CI version-check source detection (it's a version file)

## What changed (settings, already applied)

- Classic branch protection on main: **removed**
- GitHub ruleset "main protection": **created** with `test` required status check
- Ruleset bypass actors: Maintain role + app Integration (ID 3086519)
- Auto-merge: **enabled** on repo
- Repo secrets: `APP_PRIVATE_KEY` set
- Repo variables: `APP_ID` set

## Test Plan

- [x] 291 tests pass
- [ ] After merge: release workflow pushes version bump to main successfully

Closes #104