### PR TITLE
fix: remove unnecessary writing-plans prompt from brainstorming

### DIFF
--- a/plugins/dev-workflow-toolkit/skills/brainstorming/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/brainstorming/SKILL.md
@@ -242,10 +242,9 @@ When UX design is required, use **ux-design-agent** (REQUIRED SUB-SKILL) to prod
 - Use writing-clearly-and-concisely skill if available
 - Paste the design into the PR body when you open it
 
-**Implementation (if continuing):**
-- Ask: "Ready to set up for implementation?"
+**Implementation:**
 - If no worktree was created during pre-flight, use using-git-worktrees to create one
-- Use writing-plans to create detailed implementation plan
+- Invoke writing-plans to create detailed implementation plan
 
 ## Key Principles
 


### PR DESCRIPTION
## Summary
- Remove the "Ready to set up for implementation?" prompt from brainstorming's transition to writing-plans
- The process flow has no branch where brainstorming ends without invoking writing-plans, so the prompt was a false exit path
- Writing-plans already has its own context gate (65% threshold) for recommending compaction

**Review documentation gaps:** Beads task my-claude-plugins-9e4 has no review status; issue #107 has no review comments.

## Test Plan
- [x] 291 tests pass, 2 skipped
- [x] Quality gate: 85 checks passed
- [ ] Verify brainstorming skill proceeds directly to writing-plans without prompting

<details><summary>Design</summary>

The brainstorming skill's "After the Design" section contained an "Implementation (if continuing)" block that asked "Ready to set up for implementation?" before invoking writing-plans. This contradicted the process flow diagram where "Invoke writing-plans skill" is the unconditional terminal state (doublecircle node). The prompt also duplicated the context gate that writing-plans already performs at its own entry point (65% threshold with compaction recommendation).

Fix: Remove the prompt and rename the section header from "Implementation (if continuing)" to "Implementation".

</details>

Closes #107