### PR TITLE
fix: use squash merge for release version-bump PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "Created PR #$PR_NUMBER: $PR_URL"
 
-          gh pr merge "$PR_NUMBER" --rebase --auto
+          gh pr merge "$PR_NUMBER" --squash --auto
 
       - name: Wait for PR merge
         if: steps.bump.outputs.bumped == 'true'


### PR DESCRIPTION
## Summary
- Only squash merge is enabled on this repo; `--rebase` was rejected
- One-line fix: `--rebase --auto` → `--squash --auto`

## Test plan
- [ ] Merge and verify Release workflow creates + auto-merges the version bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)