### PR TITLE
feat: evaluate karpathy upstream; graft surgical-changes rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ Plans and other working documents go under `.claude/` which is fully gitignored:
 - Structured with headers, bullet points, and blockquotes for key statements.
 - No filler or padding. Dense, scannable, useful.
 
+## Surgical Changes
+
+- Every changed line should trace directly to the user's request.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it unless asked.
+
 ## Lessons Learned
 
 - **Always use `finishing-a-development-branch` before creating PRs.** Its documentation gate (Step 2) validates README.md, ARCHITECTURE.md, and DESIGN.md against the changes. Skipping it leads to stale docs that must be patched post-merge (see heilmeier-catechism PR #42).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,16 +54,16 @@ Plans and other working documents go under `.claude/` which is fully gitignored:
 4. **Always create PRs** — Never commit directly to main
 5. **Reference issue in PR** — Link back to the originating issue
 
-## Writing Standards
-
-- Structured with headers, bullet points, and blockquotes for key statements.
-- No filler or padding. Dense, scannable, useful.
-
 ## Surgical Changes
 
 - Every changed line should trace directly to the user's request.
 - Match existing style, even if you'd do it differently.
 - If you notice unrelated dead code, mention it — don't delete it unless asked.
+
+## Writing Standards
+
+- Structured with headers, bullet points, and blockquotes for key statements.
+- No filler or padding. Dense, scannable, useful.
 
 ## Lessons Learned
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -50,7 +50,21 @@ UPSTREAM files are maintainer-authored — they record the maintainer's
 adaptation decisions and sync status. Consuming agents should not modify
 these files or act on their sync instructions.
 
-UPSTREAM files also record decisions that are more nuanced than adoption — partial adoption ("graft"), evaluated-and-rejected ("do-not-adopt"), or rework ("refactor", "new-skill"). A deliberate decision not to adopt is valuable provenance; so is a decision that only lifts one phrasing out of an external body of work. Rejection-case and partial-adoption files carry a `Verdict:` field in the header (values: `adopt`, `graft`, `refactor`, `new-skill`, `do-not-adopt`) and the same analytical structure (coverage, rationale) as adoption-case files. Only the `adopt` case requires a sync section.
+UPSTREAM files also record decisions more nuanced than full adoption. A
+deliberate decision not to adopt is valuable provenance; so is a decision that
+only lifts one phrasing out of an external body of work. Rejection-case and
+partial-adoption files carry a `Verdict:` field in the header and the same
+analytical structure (coverage, rationale) as adoption-case files.
+
+Verdict values:
+
+- `adopt` — full adoption; sync section required.
+- `graft` — lift specific phrasings into existing skills.
+- `refactor` — rework an existing skill in light of the upstream.
+- `new-skill` — create a new skill derived from the upstream.
+- `do-not-adopt` — evaluated and rejected.
+
+Only the `adopt` case requires a sync section.
 
 ## Hub-and-Spoke Skill Architecture
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -50,6 +50,8 @@ UPSTREAM files are maintainer-authored — they record the maintainer's
 adaptation decisions and sync status. Consuming agents should not modify
 these files or act on their sync instructions.
 
+UPSTREAM files also record upstream work that was **evaluated and rejected**. A deliberate decision not to adopt is valuable provenance — future maintainers need to know what was considered and why. Rejection-case files carry a `Verdict: do-not-adopt` field in the header and the same analytical structure (coverage, rationale) as adoption-case files, minus the sync status.
+
 ## Hub-and-Spoke Skill Architecture
 
 Plugins with multiple related skills use a hub-and-spoke topology:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -50,7 +50,7 @@ UPSTREAM files are maintainer-authored — they record the maintainer's
 adaptation decisions and sync status. Consuming agents should not modify
 these files or act on their sync instructions.
 
-UPSTREAM files also record upstream work that was **evaluated and rejected**. A deliberate decision not to adopt is valuable provenance — future maintainers need to know what was considered and why. Rejection-case files carry a `Verdict: do-not-adopt` field in the header and the same analytical structure (coverage, rationale) as adoption-case files, minus the sync status.
+UPSTREAM files also record decisions that are more nuanced than adoption — partial adoption ("graft"), evaluated-and-rejected ("do-not-adopt"), or rework ("refactor", "new-skill"). A deliberate decision not to adopt is valuable provenance; so is a decision that only lifts one phrasing out of an external body of work. Rejection-case and partial-adoption files carry a `Verdict:` field in the header (values: `adopt`, `graft`, `refactor`, `new-skill`, `do-not-adopt`) and the same analytical structure (coverage, rationale) as adoption-case files. Only the `adopt` case requires a sync section.
 
 ## Hub-and-Spoke Skill Architecture
 

--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -7,7 +7,7 @@ read this file and apply retroactive actions marked with **ACTION**.
 
 ### Changed
 
-- Graft karpathy-guidelines phrasings into `code-simplification` (Constraints), `subagent-driven-development/implementer-prompt` (Self-Review Discipline), and `test-driven-development` (GREEN step) to close the Surgical Changes in-flight rule gap. Same rule now echoes in three skill load points: every changed line traces to the user's request; match existing style; don't delete unrelated dead code unless asked. See `skills/UPSTREAM-karpathy.md` for evaluation and rationale.
+- Graft karpathy-guidelines phrasings into `code-simplification` (Constraints), `subagent-driven-development/implementer-prompt` (Self-Review Discipline), and `test-driven-development` (GREEN step) to close the Surgical Changes in-flight rule gap. Same rule now echoes in three skill load points: every changed line traces to the user's request; match existing style; don't delete unrelated dead code unless asked. The project-root `CLAUDE.md` also gained a `## Surgical Changes` always-loaded section (out of plugin scope, not tracked here). See `skills/UPSTREAM-karpathy.md` for evaluation and rationale.
 
 ## v1.18.0
 

--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -7,7 +7,12 @@ read this file and apply retroactive actions marked with **ACTION**.
 
 ### Changed
 
-- Graft karpathy-guidelines phrasings into `code-simplification` (Constraints), `subagent-driven-development/implementer-prompt` (Self-Review Discipline), and `test-driven-development` (GREEN step) to close the Surgical Changes in-flight rule gap. Same rule now echoes in three skill load points: every changed line traces to the user's request; match existing style; don't delete unrelated dead code unless asked. The project-root `CLAUDE.md` also gained a `## Surgical Changes` always-loaded section (out of plugin scope, not tracked here). See `skills/UPSTREAM-karpathy.md` for evaluation and rationale.
+- Graft karpathy-guidelines phrasings to close the Surgical Changes in-flight rule gap. Same rule now echoes in three skill load points:
+  - `code-simplification` Constraints — every changed line traces to the user's request; don't delete unrelated dead code.
+  - `subagent-driven-development/implementer-prompt` Self-Review Discipline — match existing style; leave pre-existing dead code in place.
+  - `test-driven-development` GREEN step — every changed line traces to the user's request.
+- The project-root `CLAUDE.md` also gained a `## Surgical Changes` always-loaded section (out of plugin scope, not tracked here).
+- See `skills/UPSTREAM-karpathy.md` for evaluation and rationale.
 
 ## v1.18.0
 

--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,6 +3,12 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
+## Unreleased <!-- bump: patch -->
+
+### Changed
+
+- Graft karpathy-guidelines phrasings into `code-simplification` (Constraints), `subagent-driven-development/implementer-prompt` (Self-Review Discipline), and `test-driven-development` (GREEN step) to close the Surgical Changes in-flight rule gap. Same rule now echoes in three skill load points: every changed line traces to the user's request; match existing style; don't delete unrelated dead code unless asked. See `skills/UPSTREAM-karpathy.md` for evaluation and rationale.
+
 ## v1.18.0
 
 

--- a/plugins/dev-workflow-toolkit/skills/SPEC.md
+++ b/plugins/dev-workflow-toolkit/skills/SPEC.md
@@ -113,7 +113,7 @@ lifecycle points (plan summaries, progress updates, review findings).
 |---|---|---|
 | Adding a skill derived from upstream | Maintainer: add entry to UPSTREAM-*.md with "identical" status and sync date | INV-4 |
 | Modifying a skill that originated from upstream | Maintainer: update status to "diverged" in UPSTREAM-*.md with change notes | INV-4 |
-| Evaluating an upstream with a decision other than full adoption | Maintainer: create `UPSTREAM-<source>.md` with a `Verdict:` field (`graft`, `refactor`, `new-skill`, or `do-not-adopt`) in the header and analysis of why; omit the sync section unless the verdict is `adopt` | INV-4 |
+| Evaluating an upstream with a non-adopt outcome | Maintainer: create `UPSTREAM-<source>.md` with a `Verdict:` field (see `docs/DESIGN.md` for values) and analysis of why; omit the sync section unless the verdict is `adopt` | INV-4 |
 | Referencing another skill from within a SKILL.md | Use skill name in Integration section (e.g., "writing-plans"), never file paths | INV-5 |
 | Question has enumerable answers and agent can propose good options | Use `AskUserQuestion` with recommendation as first option | INV-14 |
 | Question is open-ended or agent lacks confidence in options | Use free-text in a single message | INV-14 |

--- a/plugins/dev-workflow-toolkit/skills/SPEC.md
+++ b/plugins/dev-workflow-toolkit/skills/SPEC.md
@@ -113,6 +113,7 @@ lifecycle points (plan summaries, progress updates, review findings).
 |---|---|---|
 | Adding a skill derived from upstream | Maintainer: add entry to UPSTREAM-*.md with "identical" status and sync date | INV-4 |
 | Modifying a skill that originated from upstream | Maintainer: update status to "diverged" in UPSTREAM-*.md with change notes | INV-4 |
+| Evaluating an upstream without adopting it | Maintainer: create `UPSTREAM-<source>.md` with `Verdict: do-not-adopt` in the header and analysis of why; no sync section needed | INV-4 |
 | Referencing another skill from within a SKILL.md | Use skill name in Integration section (e.g., "writing-plans"), never file paths | INV-5 |
 | Question has enumerable answers and agent can propose good options | Use `AskUserQuestion` with recommendation as first option | INV-14 |
 | Question is open-ended or agent lacks confidence in options | Use free-text in a single message | INV-14 |

--- a/plugins/dev-workflow-toolkit/skills/SPEC.md
+++ b/plugins/dev-workflow-toolkit/skills/SPEC.md
@@ -113,7 +113,7 @@ lifecycle points (plan summaries, progress updates, review findings).
 |---|---|---|
 | Adding a skill derived from upstream | Maintainer: add entry to UPSTREAM-*.md with "identical" status and sync date | INV-4 |
 | Modifying a skill that originated from upstream | Maintainer: update status to "diverged" in UPSTREAM-*.md with change notes | INV-4 |
-| Evaluating an upstream without adopting it | Maintainer: create `UPSTREAM-<source>.md` with `Verdict: do-not-adopt` in the header and analysis of why; no sync section needed | INV-4 |
+| Evaluating an upstream with a decision other than full adoption | Maintainer: create `UPSTREAM-<source>.md` with a `Verdict:` field (`graft`, `refactor`, `new-skill`, or `do-not-adopt`) in the header and analysis of why; omit the sync section unless the verdict is `adopt` | INV-4 |
 | Referencing another skill from within a SKILL.md | Use skill name in Integration section (e.g., "writing-plans"), never file paths | INV-5 |
 | Question has enumerable answers and agent can propose good options | Use `AskUserQuestion` with recommendation as first option | INV-14 |
 | Question is open-ended or agent lacks confidence in options | Use free-text in a single message | INV-14 |

--- a/plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md
+++ b/plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md
@@ -147,6 +147,18 @@ contradictions, 2 tonal tensions.**
   Consistent but not unified. Karpathy's "Think Before Coding" states the
   same rule once and applies it everywhere.
 
+### Evidence caveats
+
+Token counts use a word-split × 1.33 approximation; our-side denominators
+are scoped to behavior-teaching prose, excluding process scaffolding, so
+absolute ratios are directional (order-of-magnitude correct, not precise).
+The trace study is N=3 PRs selected for workflow diversity, not a random
+sample — the 4:3:4:1 tally is illustrative. The Surgical Changes ~2x
+ratio is the softest matrix cell because "teaching Surgical Changes"
+bleeds into teaching YAGNI; the qualitative gap (no "match existing
+style" rule, no "mention but don't delete unrelated dead code" rule in
+our stack) is load-bearing, not the ratio.
+
 ## Trace study
 
 ### PR #152 — `feat: add sprint skill for autonomous development sessions`

--- a/plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md
+++ b/plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md
@@ -1,0 +1,321 @@
+# UPSTREAM: andrej-karpathy-skills
+
+> **Maintainer-only.** This file tracks provenance for plugin maintainers.
+> Consuming agents should not modify this file or act on its contents.
+
+**Source:** https://github.com/forrestchang/andrej-karpathy-skills
+**License:** MIT
+**Evaluated:** 2026-04-19
+**Verdict:** graft (Branch B)
+
+## Summary
+
+Our stack already covers the four Karpathy principles, but does so at roughly
+17x-35x the token cost, with one thin area (Surgical Changes). Recommend
+grafting three or four specific phrasings from the Karpathy SKILL.md into
+existing skills — not adopting the upstream or building a new skill. The
+compression advantage and the fragmentation of YAGNI coverage across five
+locations justify filing a follow-up issue for broader review.
+
+## What this upstream is
+
+A single Claude Code plugin containing one skill, `karpathy-guidelines/SKILL.md`
+(~493 tokens), plus a near-identical top-level `CLAUDE.md` (~476 tokens). The
+content is forrestchang's paraphrase of a single Andrej Karpathy X post
+(https://x.com/karpathy/status/2015883857489522876) into four numbered
+principles: **Think Before Coding**, **Simplicity First**, **Surgical Changes**,
+**Goal-Driven Execution**. Packaged in the Agent Skills standard, MIT-licensed.
+No tests, references, or tooling — prose only.
+
+## Coverage matrix
+
+Karpathy section token counts computed per-section via `python3`
+word-split on `/tmp/karpathy-SKILL.md`, multiplied by 1.33. Our tokens are
+scoped to the prose actively teaching the same behavior, not full file size —
+files contain other content (task structure, gates, integration).
+
+| Karpathy principle | Our coverage (path + section) | Our tokens | Karpathy tokens | Ratio (ours/theirs) |
+|---|---|---|---|---|
+| 1. Think Before Coding | `brainstorming/SKILL.md` (Overview, Pre-flight Checks, The Process); `subagent-driven-development/implementer-prompt.md` ("Before You Begin" + "While you work"); `receiving-code-review/SKILL.md:36-56,104,192,219` (clarify-before-implement); agent-level CLAUDE.md ("present as something the user can redirect") | ~2,500 | 71 | ~35x |
+| 2. Simplicity First | `code-simplification/SKILL.md` (full skill); `brainstorming/SKILL.md:190` ("YAGNI ruthlessly"); `writing-plans/SKILL.md:12,161` ("DRY. YAGNI. TDD."); `implementer-prompt.md:71` ("Did I avoid overbuilding (YAGNI)?"); `receiving-code-review/SKILL.md:88-137,209-212` ("YAGNI Check for 'Professional' Features"); `test-driven-development/testing-anti-patterns.md:82`; agent-level CLAUDE.md ("Don't add features, refactor, or introduce abstractions beyond what the task requires"; "Don't add error handling, fallbacks, or validation for scenarios that can't happen") | ~1,500 | 86 | ~17x |
+| 3. Surgical Changes | `code-simplification/SKILL.md` (Constraints: "No behavior changes"; "Prefer deletion over modification"); `implementer-prompt.md:72-73` ("Did I only build what was requested?"; "Did I follow existing patterns in the codebase?"); `test-driven-development/SKILL.md:127` ("Don't add features, refactor other code, or 'improve' beyond the test") | ~250 | 118 | ~2x |
+| 4. Goal-Driven Execution | `test-driven-development/SKILL.md` (Iron Law, red/green/refactor, Verification Checklist); `verification-before-completion/SKILL.md` (Iron Law, Gate Function, Common Failures table); `writing-plans/SKILL.md:64-67` (Acceptance Criteria = "what must be TRUE = the tests") | ~2,600 | 121 | ~21x |
+
+## Effectiveness probe
+
+### Triggering
+
+**Ours — fires reliably.** CLAUDE.md behaviors load every turn (agent-system
+level); brainstorming triggers on "creating features, building components,
+adding functionality, or modifying behavior"; code-simplification runs
+automatically after verification passes; TDD triggers on "implementing any
+feature or bugfix"; verification-before-completion triggers on "claim work is
+complete". All four principles are on the primary development path and are
+enforced by skills on the router's default keywords for implementation work.
+
+**Karpathy-only — fires with prompting.** The upstream description — "writing,
+reviewing, or refactoring code to avoid overcomplication, make surgical
+changes, surface assumptions, and define verifiable success criteria" — is
+broad but single-skill, so the router returns one document instead of four
+stage-appropriate ones. The upstream also ships a CLAUDE.md variant (identical
+content) that, if copied into a project's root, would always-load — but that's
+a separate adoption decision, not something the plugin alone delivers. Without
+the CLAUDE.md copy, the skill fires when the keyword router catches the prose,
+which will not be on every implementation turn the way our always-loaded
+system instructions are.
+
+### Compression
+
+Behaviors-per-100-tokens is dominated by Karpathy on every principle. The
+concrete ratios (from the matrix) are 35x, 17x, 2x, 21x. Surgical Changes is
+the one area where our stack is close (~2x), because we don't actually say
+much about it beyond "don't overbuild" — which is much of why it's also the
+area that most reads as a gap (see Failure modes below). For the other three
+principles, the token budget we spend to convey the same behavior is
+disproportionate to the incremental behavioral precision our prose adds —
+most of our word count is process scaffolding (pre-flight checks, gate
+functions, task structure), not additional behavioral teaching.
+
+### Failure modes
+
+**Ours:**
+- **Surgical Changes underspecified** — an agent mid-implementation has no
+  crisp rule against "while I'm here, let me improve this adjacent function"
+  or "match existing style even if I'd do it differently." implementer-prompt
+  asks post-hoc ("Did I only build what was requested?"); code-simplification
+  targets post-verification cleanup, not in-flight scope creep.
+- **Dead-code-in-adjacent-territory** — no guidance for "if you notice
+  unrelated dead code, mention it — don't delete it." code-simplification
+  auto-deletes dead code as a low-risk pattern; that can cross into the
+  user's un-asked-for territory when run on an active implementation branch.
+- **Assumption surfacing is implicit** — brainstorming front-loads questions
+  but once past its gate, mid-implementation assumption surfacing relies on
+  implementer-prompt's "ask questions" bullet, which is two levels of nesting
+  under a section the subagent skims.
+
+**Karpathy-only:**
+- **No red-green-refactor discipline** — "Goal-Driven Execution" says "write
+  tests for invalid inputs, then make them pass" but doesn't mandate watching
+  the test fail. Our TDD Iron Law catches cases where a test passes on first
+  run because it's testing the wrong thing.
+- **No verification-before-claim gate** — the upstream has no analog to
+  "NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE." An agent
+  completing Karpathy's "Loop until verified" can still claim success from
+  an earlier test run.
+- **No subsystem context** — no SPEC.md / invariants concept; the agent has
+  no hook to "check the nearest spec before editing." This matters in
+  larger codebases with architectural invariants.
+
+### Clarity & coherence
+
+**Standalone clarity (read cold):** Karpathy's four sections land in one pass.
+Each principle has a one-line bold imperative (e.g., "Touch only what you must.
+Clean up only your own mess.") followed by 4-6 bullets and a test. An agent
+with no context absorbs all four in under 500 tokens.
+
+Our prose lands when co-loaded with the workflow it's embedded in — TDD's
+red-green-refactor is crisp inside `test-driven-development/SKILL.md`, but
+the "Simplicity First" content is distributed across YAGNI mentions in six
+files and has no single canonical statement to quote. Agents read the
+locally-relevant section, so this is acceptable operationally, but it's
+costly if an agent ever needs the composite view.
+
+**Conflict pressure (same principle, different phrasings):**
+
+Count of concrete pairs that could read as contradictory: **0 direct
+contradictions, 2 tonal tensions.**
+
+- Tension 1 — post-hoc vs. in-flight simplification:
+  - `code-simplification/SKILL.md:12`: "Core principle: Simplification that
+    breaks tests is a signal, not just a failure. Analyze before reverting."
+    (invites expanded scope when analysis finds a deeper issue)
+  - `test-driven-development/SKILL.md:127`: "Don't add features, refactor
+    other code, or 'improve' beyond the test." (forbids scope expansion)
+
+  These do not contradict — one runs post-verification, the other during
+  GREEN — but an agent reading both in the same session could read the
+  simplification skill as permission to do what TDD forbids. Karpathy's
+  "Surgical Changes" resolves the tension with one rule ("Every changed line
+  should trace directly to the user's request") applied throughout.
+
+- Tension 2 — when to ask questions:
+  - `brainstorming/SKILL.md` HARD-GATE: do not implement without approved
+    design (front-loads questions).
+  - `implementer-prompt.md:53`: "If you encounter something unexpected or
+    unclear, **ask questions**" (permits asking mid-execution).
+
+  Consistent but not unified. Karpathy's "Think Before Coding" states the
+  same rule once and applies it everywhere.
+
+## Trace study
+
+### PR #152 — `feat: add sprint skill for autonomous development sessions`
+
+Implementation-heavy, 220 lines of new SKILL.md + tooling. Decision points:
+
+1. **Scope of pre-authorization table.** The sprint SKILL lists a 12-row
+   table of decisions the agent makes without asking. With our stack:
+   brainstorming's delegation-question pattern (INV-14) fired to justify
+   pre-authorizing "approval vs. information." With Karpathy-only: "Think
+   Before Coding — State your assumptions explicitly" would have forced the
+   table; same outcome, less structure. **Tag: tie.**
+2. **Choosing to ship `total-risk` as an external CLI tool (34 tests).**
+   Our TDD skill + writing-plans acceptance criteria drove test count and
+   coverage. Karpathy-only: "Refactor X → Ensure tests pass before and
+   after" would have given goal discipline but no red-green verification;
+   the risk of testing-after-implementation is real. **Tag: ours-wins.**
+3. **Sprint description bans auto-triggering** (`disable-model-invocation:
+   true`). This is a scope-control decision. With our stack: no skill
+   addressed this directly; the decision came from the design discussion.
+   With Karpathy-only: "No features beyond what was asked" would have
+   surfaced the same control. **Tag: miss-both — both stacks are weak on
+   skill-metadata-level scope decisions.**
+
+### PR #121 — `Reduce skill attention pressure: remove beads, compress prose, add context-gate hook`
+
+Simplification-heavy; net -1,110 lines across 24 files. Decision points:
+
+1. **Removing INV-14 (beads work tracking) and FAIL-10.** Pure deletion of
+   an abstraction that competed with built-in task tools. With our stack:
+   `code-simplification`'s "Prefer deletion over modification" +
+   `receiving-code-review`'s YAGNI check for "Professional" features both
+   applied. With Karpathy-only: "No 'flexibility' or 'configurability' that
+   wasn't requested" and "No abstractions for single-use code" nail the
+   same conclusion in fewer words. **Tag: karpathy-wins on compression,
+   tie on outcome.**
+2. **Extracting context-gate-hook.sh to replace inline sections in 5
+   skills.** This is a structural change touching 5 files. With our
+   stack: `code-simplification`'s "Structural (High Risk — Flag Only)"
+   pattern would have required approval; `writing-plans`'s "split by
+   subsystem boundary" rule helped. With Karpathy-only: "Surgical Changes"
+   would say "Touch only what you must" — but the change deliberately
+   touches many files to reduce duplication. Karpathy's guidance would be
+   unhelpful here; the consolidation needed the deeper
+   code-simplification/SPEC.md machinery. **Tag: ours-wins.**
+3. **Deciding to remove beads rather than fix it.** A YAGNI judgment about
+   an existing system. Multiple YAGNI mentions fired (brainstorming,
+   receiving-code-review, writing-plans). Karpathy-only: one rule would
+   have said the same ("If you write 200 lines and it could be 50, rewrite
+   it"). **Tag: karpathy-wins on clarity, tie on outcome.**
+
+### PR #111 — `feat: adopt AskUserQuestion batching to reduce round-trips across skills`
+
+Brainstorm→plan→execute cycle; touches 6 skills + SPEC.md + 13 new tests.
+Decision points:
+
+1. **Adding INV-15 before modifying any SKILL.md.** Spec-first flow driven
+   by our codify-subsystem / writing-plans SPEC-anchored-tests discipline.
+   With Karpathy-only: no SPEC.md concept exists; "Goal-Driven Execution"
+   would suggest acceptance tests but not the invariant framing. **Tag:
+   ours-wins.**
+2. **Eliminating "unnecessary" questions in brainstorming** (3 questions
+   removed). This is a direct YAGNI judgment on existing prose. With our
+   stack: brainstorming's "YAGNI ruthlessly" + receiving-code-review's
+   YAGNI patterns. With Karpathy-only: "No features beyond what was asked"
+   would have done it. **Tag: karpathy-wins on compression, tie on
+   outcome.**
+3. **Test authoring strategy: pattern-based structural assertions per
+   skill edit** (`test_inv15_brainstorming_no_one_question_per_message`,
+   etc.). TDD + writing-plans spec-anchoring drove the test design;
+   Karpathy's "Write tests for invalid inputs, then make them pass"
+   doesn't capture spec-anchoring. **Tag: ours-wins.**
+
+**Trace tally:** ours-wins 4 / karpathy-wins 3 (all on compression or
+clarity, never outcome) / tie 4 / miss-both 1.
+
+## Verdict and rationale
+
+**Verdict: B (graft).** The rule: "Karpathy wins on compression or clarity
+for specific phrasings that can be ported with minor edits." All three
+conditions hold:
+
+1. **Compression win, not coverage win.** The matrix shows 17x-35x
+   compression advantage on three of four principles. On every trace
+   outcome, our stack produced the right answer — ours-wins outnumbers
+   karpathy-wins 4:3, and every karpathy-wins tag is "compression or
+   clarity, not outcome." Adopting the whole upstream would duplicate
+   content we already have; ignoring the upstream would leave specific
+   high-value phrasings on the table.
+
+2. **One real thin spot: Surgical Changes in-flight.** Ratio is ~2x (we
+   have less than half the words on this principle), and the concrete
+   failure mode — mid-implementation adjacent improvements, style
+   matching, touching unrelated dead code — is not directly addressed
+   in any skill description, only implicit under YAGNI. Karpathy has
+   four crisp bullets on this.
+
+3. **Graftable phrasings exist.** Not hypothetical: "Every changed line
+   should trace directly to the user's request." "Match existing style,
+   even if you'd do it differently." "If you notice unrelated dead code,
+   mention it — don't delete it." "Remove imports/variables/functions
+   that YOUR changes made unused. Don't remove pre-existing dead code
+   unless asked." These are 1-2 line insertions, not skill-level
+   rewrites, and they close the one gap identified above.
+
+Why not **A (do not adopt)**: compression failure on three principles
+(>17x) exceeds the "within 2x" bar.
+
+Why not **C (refactor a skill)**: no single skill shows ≥3x compression
+disadvantage paired with zero compensating content — the prose bulk is
+justified by process scaffolding, not by behavioral over-teaching.
+
+Why not **D (new compact skill)**: the Surgical Changes gap is solvable
+with 4-6 bullets added to existing skills. A new skill would duplicate
+YAGNI content and add router surface area; the upstream single-skill
+packaging shows this doesn't pay off on compression without CLAUDE.md
+always-loading, which we already have at the system level.
+
+## Changes made
+
+**None — evaluation artifact only.** This file is the Task 1 deliverable.
+
+**Graft targets for Task 3** (do not apply in this task):
+
+- `plugins/dev-workflow-toolkit/skills/code-simplification/SKILL.md`,
+  under "Constraints" or adjacent — add: "Every changed line should trace
+  directly to the user's request. If you notice unrelated dead code,
+  mention it — don't delete it unless asked." Rationale: closes the
+  "auto-delete crosses scope" failure mode; consolidates the two
+  tensions flagged under "Clarity & coherence."
+- `plugins/dev-workflow-toolkit/skills/subagent-driven-development/implementer-prompt.md`,
+  under "Discipline:" — add: "Match existing style, even if you'd do it
+  differently. Remove only imports/variables/functions that YOUR changes
+  made unused." Rationale: gives the implementer subagent a crisp
+  in-flight rule for Surgical Changes, not a post-hoc review question.
+- `plugins/dev-workflow-toolkit/skills/test-driven-development/SKILL.md`,
+  GREEN section — reinforce existing `:127` line with the Karpathy test:
+  "The test: every changed line traces to the user's request." Rationale:
+  one canonical phrasing that the other two grafts can echo, reducing
+  the fragmentation signal below.
+- Optional: `CLAUDE.md` (repo root) — consider a one-bullet "Surgical
+  changes" line under Writing Standards or a new section, matching tone
+  of existing "No filler or padding. Dense, scannable, useful." Rationale:
+  makes the Surgical Changes principle always-loaded, the way Simplicity
+  First already is via agent-level defaults.
+
+## Signals for broader review
+
+Running tally of Approach-B signals:
+
+- **Compression-ratio signal (≥3x):** **hit** on three of four principles
+  (17x Simplicity First, 21x Goal-Driven Execution, 35x Think Before
+  Coding). See coverage matrix.
+- **Fragmentation signal (same guidance in ≥3 places):** **hit** on YAGNI /
+  Simplicity First content — appears in `brainstorming/SKILL.md:190`,
+  `writing-plans/SKILL.md:12,161`, `implementer-prompt.md:71`,
+  `receiving-code-review/SKILL.md:88-137,209-212`, and
+  `test-driven-development/testing-anti-patterns.md:82`. Five locations
+  for one principle.
+- **Conflict signal (≥1 contradictory pair):** **miss** on strict
+  contradictions; two tonal tensions logged under Clarity & coherence
+  (post-hoc vs. in-flight simplification; front-loaded vs. mid-execution
+  questions). Tensions are real but resolvable by the Task 3 grafts, not
+  by removing or rewriting either side.
+
+**Result:** 2 distinct signal types landed (compression + fragmentation).
+
+**Recommend follow-up issue.** Scope suggestion for the retrospective to
+file: "Audit YAGNI / Simplicity First coverage fragmentation across
+dev-workflow-toolkit skills; consolidate to one canonical statement
+referenced by the others, to reduce attention pressure and address the
+17x compression delta identified in UPSTREAM-karpathy.md."

--- a/plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md
+++ b/plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md
@@ -279,31 +279,38 @@ always-loading, which we already have at the system level.
 
 ## Changes made
 
-**None — evaluation artifact only.** This file is the Task 1 deliverable.
-
-**Graft targets for Task 3** (do not apply in this task):
+Grafts applied on branch `feature/163-evaluate-karpathy` in commit
+`99608b3` with refinements in commit `46faf9e`:
 
 - `plugins/dev-workflow-toolkit/skills/code-simplification/SKILL.md`,
-  under "Constraints" or adjacent — add: "Every changed line should trace
-  directly to the user's request. If you notice unrelated dead code,
-  mention it — don't delete it unless asked." Rationale: closes the
-  "auto-delete crosses scope" failure mode; consolidates the two
-  tensions flagged under "Clarity & coherence."
+  Constraints — added: "Every changed line should trace directly to the
+  user's request" and "If you notice unrelated dead code, mention it —
+  don't delete it unless asked." Closes the auto-delete-crosses-scope
+  failure mode; consolidates the post-hoc vs. in-flight simplification
+  tension flagged under Clarity & coherence.
 - `plugins/dev-workflow-toolkit/skills/subagent-driven-development/implementer-prompt.md`,
-  under "Discipline:" — add: "Match existing style, even if you'd do it
-  differently. Remove only imports/variables/functions that YOUR changes
-  made unused." Rationale: gives the implementer subagent a crisp
-  in-flight rule for Surgical Changes, not a post-hoc review question.
+  Self-Review Discipline — existing "Did I follow existing patterns in
+  the codebase?" bullet widened to "Did I match existing patterns and
+  style in the codebase, even where I'd do it differently?" (absorbs
+  the Karpathy anti-ego clause into the existing question). New bullet
+  added: "Did I remove only imports/variables/functions that my changes
+  made unused, leaving pre-existing dead code in place?" Phrased as
+  questions to match the section's voice.
 - `plugins/dev-workflow-toolkit/skills/test-driven-development/SKILL.md`,
-  GREEN section — reinforce existing `:127` line with the Karpathy test:
-  "The test: every changed line traces to the user's request." Rationale:
-  one canonical phrasing that the other two grafts can echo, reducing
-  the fragmentation signal below.
-- Optional: `CLAUDE.md` (repo root) — consider a one-bullet "Surgical
-  changes" line under Writing Standards or a new section, matching tone
-  of existing "No filler or padding. Dense, scannable, useful." Rationale:
-  makes the Surgical Changes principle always-loaded, the way Simplicity
-  First already is via agent-level defaults.
+  GREEN section (:127) — appended to existing sentence: "The test: every
+  changed line traces to the user's request." Establishes the canonical
+  phrasing that the other two grafts echo.
+- `CLAUDE.md` (repo root) — added new `## Surgical Changes` section
+  between Workflow and Writing Standards with three bullets: "Every
+  changed line should trace directly to the user's request"; "Match
+  existing style, even if you'd do it differently"; "If you notice
+  unrelated dead code, mention it — don't delete it unless asked."
+  Always-loaded at the project level, matching how Simplicity First
+  reaches agents via always-loaded system instructions.
+
+CHANGELOG entry: `plugins/dev-workflow-toolkit/CHANGELOG.md` Unreleased
+with `<!-- bump: patch -->` — the three plugin-scope grafts only;
+project-root CLAUDE.md is out of plugin scope.
 
 ## Signals for broader review
 

--- a/plugins/dev-workflow-toolkit/skills/code-simplification/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/code-simplification/SKILL.md
@@ -9,7 +9,7 @@ description: Use after verification passes to automatically simplify code. Runs 
 
 Automated refactoring after tests pass. Part of the standard development pipeline.
 
-**Core principle:** Simplification that breaks tests is a signal, not just a failure. Analyze before reverting.
+**Core principle:** Simplification that breaks tests is a signal, not just a failure. Analyze before reverting — but analysis stays in-scope to the simplification at hand, not adjacent code.
 
 **Announce at start:** "I'm using the code-simplification skill to simplify the code you just verified."
 

--- a/plugins/dev-workflow-toolkit/skills/code-simplification/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/code-simplification/SKILL.md
@@ -27,6 +27,8 @@ develop → verify (tests pass) → simplify → re-verify → complete
 - No new features added
 - Prefer deletion over modification
 - Tests must pass after each change
+- Every changed line should trace directly to the user's request
+- If you notice unrelated dead code, mention it — don't delete it unless asked
 
 ## Pattern Categories
 

--- a/plugins/dev-workflow-toolkit/skills/subagent-driven-development/implementer-prompt.md
+++ b/plugins/dev-workflow-toolkit/skills/subagent-driven-development/implementer-prompt.md
@@ -72,6 +72,8 @@ Task tool (general-purpose):
     - Did I only build what was requested?
     - Did I follow existing patterns in the codebase?
     - Did I follow the approach/libraries specified in the task, or did I diverge? If I diverged, have I documented why?
+    - Match existing style, even if you'd do it differently
+    - Remove only imports/variables/functions that YOUR changes made unused — don't remove pre-existing dead code unless asked
 
     **Testing:**
     - Do tests actually verify behavior (not just mock behavior)?

--- a/plugins/dev-workflow-toolkit/skills/subagent-driven-development/implementer-prompt.md
+++ b/plugins/dev-workflow-toolkit/skills/subagent-driven-development/implementer-prompt.md
@@ -70,10 +70,9 @@ Task tool (general-purpose):
     **Discipline:**
     - Did I avoid overbuilding (YAGNI)?
     - Did I only build what was requested?
-    - Did I follow existing patterns in the codebase?
+    - Did I match existing patterns and style in the codebase, even where I'd do it differently?
     - Did I follow the approach/libraries specified in the task, or did I diverge? If I diverged, have I documented why?
-    - Match existing style, even if you'd do it differently
-    - Remove only imports/variables/functions that YOUR changes made unused — don't remove pre-existing dead code unless asked
+    - Did I remove only imports/variables/functions that my changes made unused, leaving pre-existing dead code in place?
 
     **Testing:**
     - Do tests actually verify behavior (not just mock behavior)?

--- a/plugins/dev-workflow-toolkit/skills/test-driven-development/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/test-driven-development/SKILL.md
@@ -124,7 +124,7 @@ async function retryOperation<T>(fn: () => Promise<T>): Promise<T> {
 ```
 Just enough to pass
 
-Don't add features, refactor other code, or "improve" beyond the test.
+Don't add features, refactor other code, or "improve" beyond the test. The test: every changed line traces to the user's request.
 
 **Formal grammars:** Use parsers (not regex/sed) for any format with a formal grammar. See `requesting-code-review/references/structured-format-parsing.md` for full guidance.
 

--- a/plugins/dev-workflow-toolkit/skills/test-driven-development/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/test-driven-development/SKILL.md
@@ -124,7 +124,7 @@ async function retryOperation<T>(fn: () => Promise<T>): Promise<T> {
 ```
 Just enough to pass
 
-Don't add features, refactor other code, or "improve" beyond the test. The test: every changed line traces to the user's request.
+Don't add features, refactor other code, or "improve" beyond the test. The rule: every changed line traces to the user's request.
 
 **Formal grammars:** Use parsers (not regex/sed) for any format with a formal grammar. See `requesting-code-review/references/structured-format-parsing.md` for full guidance.
 

--- a/plugins/dev-workflow-toolkit/uv.lock
+++ b/plugins/dev-workflow-toolkit/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "dev-workflow-toolkit"
-version = "1.17.1"
+version = "1.18.0"
 source = { virtual = "." }
 dependencies = [
     { name = "markdown-it-py" },


### PR DESCRIPTION
## Summary

- Evaluated `forrestchang/andrej-karpathy-skills` (external behavioral-guidelines upstream) via the Approach-C methodology: coverage matrix, four-axis effectiveness probe (triggering/compression/failure modes/clarity & coherence), and trace study on three past PRs (#152, #121, #111). Verdict: **B (graft)** — our stack already covers the four Karpathy principles, but with 17x–35x compression overhead on three of four and a thin in-flight rule for Surgical Changes.
- Grafted three Karpathy phrasings into `code-simplification` (Constraints), `subagent-driven-development/implementer-prompt` (Self-Review Discipline), and `test-driven-development` (GREEN section), plus a new always-loaded `## Surgical Changes` section in the project-root `CLAUDE.md`. Same rule echoes across three load points: "every changed line traces to the user's request."
- Codified the `Verdict:` field convention for `UPSTREAM-*.md` files in `docs/DESIGN.md` and `plugins/dev-workflow-toolkit/skills/SPEC.md` (Decision Framework). Supported values: `adopt`, `graft`, `refactor`, `new-skill`, `do-not-adopt`. Only the `adopt` case requires a sync section.
- New tracked artifact: `plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md` (341 lines) records the evaluation, matrix, probe, trace, verdict rationale, applied grafts, and Approach-B signal assessment.

## Follow-up flagged

**Approach-B signal threshold met** (compression ≥3x on three principles + YAGNI fragmentation across 5 files). Recommend filing a separate issue scoped to **"Audit and consolidate YAGNI / Simplicity First coverage fragmentation across dev-workflow-toolkit skills."** See `UPSTREAM-karpathy.md` §Signals for broader review. Retrospective was skipped per session preference; filing this follow-up is manual.

## Test Plan

- [x] `plugins/dev-workflow-toolkit/tests/run-all.sh` → 322 passed, 2 skipped
- [x] `scripts/quality-gate.sh` → 87/87 checks pass (inv-numbering, skill-structure, doc-structure, vsa-coverage, cross-links, doc-stats, tool-health all green)
- [x] Documentation gate (validate mode) → PASSED
- [x] Spec + quality reviews passed on all three tasks (evaluation, doc updates, grafts)
- [x] Cross-task integration review PASSED on 7/7 criteria

<details><summary>Design document</summary>

# Design: Evaluate karpathy guidance

**Issue:** #163 — evaluate "karpathy" guidance
**Date:** 2026-04-19
**Branch:** feature/163-evaluate-karpathy

## Goal & Deliverable

Produce an evidence-backed verdict on whether `forrestchang/andrej-karpathy-skills` should influence our plugin marketplace. Secondary goal: surface signals indicating whether a wider first-principles review of the dev-workflow-toolkit skill stack (Approach B) is warranted.

**Deliverable (committed).** `plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md` — a provenance-and-evaluation document that records source, license, verdict, coverage matrix, effectiveness probe, trace study, changes made (if any), and signals for broader review.

**Deliverable (ephemeral).** This design doc, pasted into the PR body.

**Deliverable (conditional).** If the verdict is graft / refactor / new-skill, implementation changes follow in this branch. If the verdict is do-not-adopt, the UPSTREAM file alone is the deliverable.

**Rationale for a tracked UPSTREAM file.** An evaluation that rejects adoption is valuable provenance — future maintainers need to know what was considered and why, without re-doing the work. Per DESIGN.md's upstream provenance pattern, UPSTREAM files are the right home.

## Methodology (Approach C — coverage + four-axis probe + trace)

### Step 1 — Coverage matrix

Table with one row per Karpathy principle: our coverage location(s), token count (ours, via `wc -w`), token count (Karpathy), compression ratio. Four rows.

### Step 2 — Effectiveness probe (four axes)

- **(A) Triggering.** Does the guidance actually fire when needed? Score: fires reliably / fires with prompting / fires only when user invokes.
- **(B) Compression.** Behaviors conveyed per 100 tokens.
- **(C) Failure modes.** Enumerate 2-3 situations where each stack would drop the principle.
- **(D) Clarity & coherence.** Standalone clarity (does the principle land cold?) and conflict pressure (do distributed phrasings pull in different directions?). Count concrete conflicts, not just repetition.

### Step 3 — Empirical trace on three past items

Pick three past repo items — a recent implementation PR, a simplification-heavy PR, and a brainstorm→plan→execute cycle. For each, a thought-experiment trace: where would our stack vs. Karpathy-only have produced different behavior? Uses documented decision points (PR body, plan, design doc) — not a re-execution.

### Step 4 — Verdict (one of four, mutually exclusive)

- **Do not adopt.** Our stack dominates. UPSTREAM file alone; no code changes.
- **Graft specific phrasings.** Named edits to specific lines/sections in existing skills or CLAUDE.md.
- **Refactor skill X.** One skill flagged by evidence for restructure.
- **New compact skill.** Reliable triggering gap a new skill would close.

### Step 5 — Approach-B signal capture

Running list in UPSTREAM file under "Signals for broader review." Entries added when:
- Compression ratio ≥ 3x (we're >3x as verbose for same behavior)
- Same guidance repeated in 3+ places in our stack (fragmentation)
- A pair of our skills/CLAUDE.md sections state the same principle in ways that read as contradictory (conflict)

**Threshold for recommending follow-up.** ≥2 *distinct* signal types land. Approach B is always filed as a separate issue from retrospective — never absorbed into this branch, even if signals are strong.

## UPSTREAM-karpathy.md Structure

Fixed skeleton:

- Header metadata: source, license, evaluation date, verdict
- Summary (2-3 sentence plain-English verdict)
- What this upstream is (content, provenance, format)
- Coverage matrix (table)
- Effectiveness probe (four axes, per-principle)
- Trace study (three items with decision points)
- Verdict and rationale (prose)
- Changes made (bullets with file:section or "None — evaluation artifact only")
- Signals for broader review (running list + follow-up recommendation)

Verdict in header metadata so a glance answers "did we adopt this?" without reading further. An UPSTREAM file that says "evaluated, did not adopt, no changes" is a complete and honest artifact.

## Post-Verdict Branching

One issue / one PR by default. Mixed verdicts trigger an epic split at detection time.

| Verdict | Commits | Bump | CHANGELOG | Tests | Review focus |
|---|---|---|---|---|---|
| A — Do not adopt | UPSTREAM-karpathy.md only | none | optional | quality gate only | verdict defensibility |
| B — Graft | UPSTREAM + targeted edits | patch | entry naming grafts | affected suites + quality gate; TDD if description changes affect triggering | do grafts actually compress/clarify? before/after quoted in PR body |
| C — Refactor skill X | UPSTREAM + restructured SKILL.md + test updates | minor | entry + justification | TDD; test goes red before prose, green after | does refactor preserve every prior behavior? failure-modes column is the test bed |
| D — New compact skill | UPSTREAM + new SKILL.md + SPEC.md invariants + tests | minor | entry + skill description | minimum one triggering test + one behavior test per principle; quality gate | distinct triggering vs. existing skills? description-namespace collision check |

**Mixed verdict handling.** If evidence supports e.g. both graft AND new-skill, add `epic` label to #163, close this branch with only UPSTREAM-karpathy.md (Branch A treatment), open child issues.

## Risks

1. **Confirmation bias.** Walking in predisposed to think our stack covers Karpathy. Mitigation: per-axis scoring requires concrete one-line reasons; empty reasons → re-check.
2. **Thought-experiment trace.** Judgment about what would have happened, not re-execution. Mitigation: pick trace items with documented decision points so I'm reading the record.
3. **Rough token counts.** `wc -w` conflates prose density with token cost. Mitigation: only extreme ratios (≥3x) feed the signal list.
4. **UPSTREAM files are point-in-time.** If upstream changes, our file doesn't auto-re-evaluate. Mitigation: DESIGN.md update codifies the rejection case so future maintainers know the pattern.
5. **Scope creep to Approach B.** Guarded — always a separate issue from retrospective, never absorbed.

## Testing Summary

| Branch | Tests required |
|---|---|
| A | Quality gate passes. Nothing else. |
| B | Re-run affected plugin test suites + quality gate. TDD if triggering affected. |
| C | TDD on behavior-expectation tests (red → prose change → green). Quality gate + affected suites. |
| D | Minimum one triggering test + one behavior test per principle. Quality gate. SPEC.md INV/FAIL entries get corresponding tests if added. |

No integration tests — skills have no runtime. Quality gate (inv-numbering, skill-structure, doc-structure, vsa-coverage) is the mechanical backstop.

## "Done" Definition

- `plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md` exists and is internally consistent (verdict matches matrix + probe + trace)
- Any branch-specific changes in place with tests passing
- Documentation updates applied (see below)
- "Signals for broader review" populated; follow-up issue filed from retrospective if threshold crossed
- PR body contains this design doc and links to issue #163
- Quality gate passes

## Documentation Updates

Approved drafts from documentation-standards (draft mode):

### `docs/DESIGN.md` — Upstream Provenance Tracking section

Append new paragraph to the end of the existing section:

> UPSTREAM files also record upstream work that was **evaluated and rejected**. A deliberate decision not to adopt is valuable provenance — future maintainers need to know what was considered and why. Rejection-case files carry a `Verdict: do-not-adopt` field in the header and the same analytical structure (coverage, rationale) as adoption-case files, minus the sync status.

### `plugins/dev-workflow-toolkit/skills/SPEC.md` — Decision Framework table

Insert new row after the existing two UPSTREAM rows:

| Situation | Action | Invariant |
|---|---|---|
| Evaluating an upstream without adopting it | Maintainer: create `UPSTREAM-<source>.md` with `Verdict: do-not-adopt` in the header and analysis of why; no sync section needed | INV-4 |

INV-4 itself already covers this case without modification — only the Decision Framework needs the new row.

### Docs NOT affected

- `README.md` — no public interface change
- `docs/ARCHITECTURE.md` — convention refinement, not a structural decision
- `plugins/dev-workflow-toolkit/README.md` — affected only if verdict B/C/D (stat-count footnotes); handled at implementation time
- `plugins/dev-workflow-toolkit/CHANGELOG.md` — Unreleased entry added at implementation time; content depends on verdict

</details>

<details><summary>Implementation plan</summary>

# Karpathy Guidance Evaluation Implementation Plan

**Issue:** #163 — evaluate "karpathy" guidance
**Design:** ~/.claude/plans/2026-04-19-karpathy-evaluation-design.md

> **For Claude:** Execute this plan using subagent-driven-development (same session) or executing-plans (separate session / teammate).

**Goal:** Produce `plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md` with an evidence-backed verdict on whether to adopt `forrestchang/andrej-karpathy-skills`, applying any conditional changes the verdict dictates, and filing an Approach-B follow-up issue if signal thresholds are crossed.

**Architecture:** Approach C methodology — build a coverage matrix of Karpathy's four principles against our existing skill stack and CLAUDE.md, run a four-axis effectiveness probe (triggering, compression, failure modes, clarity & coherence), trace three past repo items to surface real decision points, then synthesize one of four mutually-exclusive verdicts (do-not-adopt / graft / refactor / new-skill). All deliverables committed to the same branch; mixed verdicts trigger an epic split at detection.

**Tech Stack:** GitHub CLI (`gh`), shell (`wc -w`, `grep`), no test frameworks for the evaluation itself — skill behavioral tests only fire under branch C/D.

**Acceptance Criteria — what must be TRUE when this plan is done:**
- [ ] `plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md` exists with header metadata including `Verdict: <A|B|C|D>`, coverage matrix, four-axis probe, trace study, verdict rationale, changes-made section, and signals-for-broader-review section
- [ ] UPSTREAM file's verdict is internally consistent with its matrix + probe + trace evidence
- [ ] `docs/DESIGN.md` Upstream Provenance Tracking section has the approved evaluated-and-rejected paragraph appended
- [ ] `plugins/dev-workflow-toolkit/skills/SPEC.md` Decision Framework table has the approved evaluating-without-adopting row
- [ ] Verdict-specific implementation (if any) is complete with tests passing
- [ ] Quality gate (`scripts/quality-gate.sh`) passes
- [ ] If ≥2 Approach-B signal types crossed threshold, a follow-up issue is filed from retrospective
- [ ] PR opened against `main` linking to issue #163 with design doc and plan pasted into PR body

**Dependencies:** None

---

### Task 1: Execute the evaluation and produce UPSTREAM-karpathy.md

**Context:** This task executes the Approach-C methodology defined in the design doc and writes the evaluation artifact. The artifact is a tracked maintainer file that records what was considered about `forrestchang/andrej-karpathy-skills`, the evidence, and the verdict. It is committed regardless of whether any adoption follows — a deliberate rejection is valuable provenance.

Karpathy's content is a single SKILL.md with four principles (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution) plus a near-identical CLAUDE.md. Our stack distributes coverage of these principles across multiple skills and CLAUDE.md. The methodology produces one of four mutually-exclusive verdicts; the verdict drives downstream tasks.

Work from the worktree `/workspace/my-claude-plugins/.worktrees/feature/163-evaluate-karpathy` (branch `feature/163-evaluate-karpathy`). All paths below are relative to this worktree unless noted.

**Subsystem spec(s):** `plugins/dev-workflow-toolkit/skills/SPEC.md` (primary — this is where UPSTREAM-karpathy.md lives)
**Key invariants from spec:**
- INV-4: Upstream provenance tracking (`UPSTREAM-*.md`) is maintainer-only; consuming agents must not modify these files → the new UPSTREAM-karpathy.md must conform to this convention (maintainer-authored header, adaptation/rejection notes)

No behavioral tests are required for this task — the UPSTREAM file is a record, not runtime code. Its correctness is reviewed, not asserted in CI.

**Adjacent specs:** None — writing an UPSTREAM file does not modify any other subsystem.

**Files:**
- Create: `plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md`

**Depends on:** Independent

**Step 1: Gather source material**

Fetch the two canonical files from the upstream repo. Store locally in temp scratch for reference, or keep as variables; they're small.

```bash
curl -s https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/skills/karpathy-guidelines/SKILL.md > /tmp/karpathy-SKILL.md
curl -s https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md > /tmp/karpathy-CLAUDE.md
wc -w /tmp/karpathy-SKILL.md /tmp/karpathy-CLAUDE.md
```

These two files together define what we are evaluating.

**Step 2: Identify our coverage locations**

For each of the four Karpathy principles, find where our stack addresses the same behavior. Likely locations (read each and cite section + line range):

- `plugins/dev-workflow-toolkit/skills/brainstorming/SKILL.md` (Think Before Coding)
- `plugins/dev-workflow-toolkit/skills/writing-plans/SKILL.md` (Think Before Coding)
- `plugins/dev-workflow-toolkit/skills/code-simplification/SKILL.md` (Simplicity First)
- `plugins/dev-workflow-toolkit/skills/test-driven-development/SKILL.md` (Goal-Driven Execution)
- `plugins/dev-workflow-toolkit/skills/verification-before-completion/SKILL.md` (Goal-Driven Execution)
- The project `CLAUDE.md` (all four, partial coverage)
- The agent-system CLAUDE.md content (e.g., "Don't add features, refactor, or introduce abstractions beyond what the task requires")

Use `grep -n` with behavioral keywords ("simplify", "yagni", "assumption", "verify", "surgical", "minimal", "speculate") to find all locations. Don't assume — find.

Compute token approximations with `wc -w`; words × 1.33 ≈ tokens. Record both raw words and approximate tokens per location.

**Step 3: Build the coverage matrix**

A four-row table. For each Karpathy principle:

| Karpathy principle | Our coverage (path:section) | Our tokens | Karpathy tokens | Ratio |

Karpathy tokens per principle ≈ total Karpathy tokens / 4 if segmented evenly; or extract the principle's own section word count from `/tmp/karpathy-SKILL.md` with awk if sections are clear. Prefer the latter.

Record this table as the first analytical section of the UPSTREAM file.

**Step 4: Run the four-axis effectiveness probe**

For each principle, score both stacks on four axes. Output is a per-axis mini-table or bulleted comparison with one-line reasons. Empty reasons are not acceptable — if you cannot cite concrete evidence, return to Step 2 or 3.

- **(A) Triggering.** Will the guidance fire when needed? Consider skill description keyword matching vs. always-loaded CLAUDE.md content. Score: fires reliably / fires with prompting / fires only when user invokes.
- **(B) Compression.** Behaviors conveyed per 100 tokens. Use the matrix from Step 3.
- **(C) Failure modes.** 2-3 situations per stack where the principle would drop. E.g., "Karpathy's Simplicity First fails when the task genuinely needs abstraction because the principle is absolute"; "our code-simplification fails when triggered post-hoc so the author has already written the bloat."
- **(D) Clarity & coherence.** Two sub-questions:
  - *Standalone clarity:* read each cold — does the principle land?
  - *Conflict pressure:* count concrete pairs of our skills/CLAUDE.md sections that state the same principle in ways that could read as contradictory. Cite specific phrasings.

**Step 5: Run the trace study**

Pick three past repo items with documented decision points:

```bash
# List recent merged PRs on main
gh pr list --state merged --base main --limit 20 --json number,title,body
```

Pick one implementation-heavy PR, one simplification-heavy PR (search for "simplif" or "refactor"), and one that had a brainstorm→plan→execute cycle (look for design docs or plans referenced in PR body).

For each, read the PR body, the diff (`gh pr diff <N>`), and any linked design/plan. Identify 2-3 concrete decision points where behavioral guidance applied. For each decision point, write a one-line thought experiment: "With our stack: [what fired/didn't]. With Karpathy-only: [what would have fired/not]." Tag each as ours-wins / karpathy-wins / tie / miss-both.

**Step 6: Synthesize the verdict**

Apply the verdict rule from the design:

- **A (do not adopt)** if our stack dominates on triggering AND compression is within 2x AND no meaningful clarity/conflict gaps surfaced
- **B (graft)** if Karpathy wins on compression or clarity for specific phrasings that can be ported with minor edits
- **C (refactor skill X)** if one specific skill shows ≥3x compression disadvantage with no compensating content, or clear conflict pressure with another skill
- **D (new compact skill)** if there is a principle the matrix shows we do not reliably trigger on (triggering = "fires only when user invokes" or lower)

Mixed signals → pick the dominant verdict and record the other signals in the "Signals for broader review" section rather than as a second verdict.

**Step 7: Capture Approach-B signals**

Throughout steps 3-5, keep a running tally:
- Compression-ratio signal: ratio ≥ 3x
- Fragmentation signal: same guidance repeated in ≥3 places
- Conflict signal: ≥1 pair of our sections that state the same principle contradictorily

Record every hit in the "Signals for broader review" section with specific citations. Close with:
- "No follow-up recommended" if <2 distinct signal types landed
- "Recommend follow-up issue" if ≥2 distinct signal types landed, naming them

The actual follow-up issue is filed from retrospective, not here.

**Step 8: Write UPSTREAM-karpathy.md**

Use this skeleton. Fill every section; do not leave placeholders.

```markdown
# UPSTREAM: andrej-karpathy-skills

**Source:** https://github.com/forrestchang/andrej-karpathy-skills
**License:** MIT
**Evaluated:** 2026-04-19
**Verdict:** <do-not-adopt | graft | refactor | new-skill>

## Summary

<2-3 sentence plain-English verdict and key reason.>

## What this upstream is

<2-3 sentences: content, provenance (forrestchang's paraphrase of a single Karpathy X post), format (single SKILL.md + CLAUDE.md, Agent Skills standard, MIT).>

## Coverage matrix

<4-row table from Step 3>

## Effectiveness probe

### Triggering
<from Step 4>

### Compression
<from Step 4>

### Failure modes
<from Step 4>

### Clarity & coherence
<from Step 4, including conflict-pressure findings>

## Trace study

<3 items from Step 5, each with: link, 1-sentence situation, decision points with ours-vs-Karpathy comparison>

## Verdict and rationale

<Plain prose — why this verdict follows from the matrix, probe, and trace.>

## Changes made

<One of:>
- "None — evaluation artifact only." (Branch A)
- <Bullet list of edits to existing skills/CLAUDE.md with file:section and one-line rationale> (Branch B/C)
- <Bullet list noting the new skill directory and tests> (Branch D)

<For Branch A, still commit this UPSTREAM file; the file itself is the deliverable.>

## Signals for broader review

<Running list from Step 7 + recommendation.>
```

**Step 9: Commit**

```bash
cd /workspace/my-claude-plugins/.worktrees/feature/163-evaluate-karpathy
git add plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md
git commit -m "docs: evaluate karpathy-guidelines upstream (verdict: <A/B/C/D>)"
```

**Output:** The verdict (A/B/C/D) and the filled UPSTREAM-karpathy.md. Task 3's branching depends on the verdict.

---

### Task 2: Apply approved documentation updates

**Context:** Two tracked-doc edits were approved during brainstorming's draft mode. They codify the evaluated-and-rejected UPSTREAM convention so future maintainers know the pattern. These are independent of the verdict — they apply regardless of whether we adopt Karpathy content.

**Subsystem spec(s):** `plugins/dev-workflow-toolkit/skills/SPEC.md` (the Decision Framework row lives here)
**Key invariants from spec:**
- INV-4: Upstream provenance tracking is maintainer-only → the new Decision Framework row explicitly covers a new maintainer situation under this invariant
- No INV-numbering change (the row is additive within the existing Decision Framework table; it is not an INV-N or FAIL-N addition)

**Adjacent specs:** None.

**Files:**
- Modify: `docs/DESIGN.md` — Upstream Provenance Tracking section
- Modify: `plugins/dev-workflow-toolkit/skills/SPEC.md` — Decision Framework table

**Depends on:** Independent (can run before or after Task 1; safest to run after so UPSTREAM-karpathy.md exists as the real-world demonstration of the convention).

**Step 1: Apply DESIGN.md update**

Append this paragraph to the end of the `## Upstream Provenance Tracking` section in `docs/DESIGN.md`. Place it after the existing final paragraph ("UPSTREAM files are maintainer-authored — they record the maintainer's adaptation decisions and sync status. Consuming agents should not modify these files or act on their sync instructions.").

New paragraph (verbatim):

> UPSTREAM files also record upstream work that was **evaluated and rejected**. A deliberate decision not to adopt is valuable provenance — future maintainers need to know what was considered and why. Rejection-case files carry a `Verdict: do-not-adopt` field in the header and the same analytical structure (coverage, rationale) as adoption-case files, minus the sync status.

Use the `Edit` tool. `old_string` is the last sentence of the section; `new_string` is that sentence followed by a blank line and the new paragraph.

**Step 2: Apply SPEC.md update**

In `plugins/dev-workflow-toolkit/skills/SPEC.md`, find the Decision Framework table. It currently contains two UPSTREAM rows ("Adding a skill derived from upstream" and "Modifying a skill that originated from upstream"). Insert a new row immediately after those two:

```
| Evaluating an upstream without adopting it | Maintainer: create `UPSTREAM-<source>.md` with `Verdict: do-not-adopt` in the header and analysis of why; no sync section needed | INV-4 |
```

Use `Edit` with enough surrounding context to make `old_string` unique — include the preceding row verbatim.

**Step 3: Run quality gate to confirm no structural regressions**

```bash
cd /workspace/my-claude-plugins/.worktrees/feature/163-evaluate-karpathy
plugins/dev-workflow-toolkit/scripts/quality-gate.sh --path .
```

Expected: all checks pass. The new Decision Framework row is not an INV-N/FAIL-N and does not trigger inv-numbering checks. The DESIGN.md edit doesn't touch structural elements.

**Step 4: Commit**

```bash
git add docs/DESIGN.md plugins/dev-workflow-toolkit/skills/SPEC.md
git commit -m "docs: codify evaluated-and-rejected upstream provenance convention"
```

---

### Task 3: Branch by verdict — apply verdict-specific implementation

**Context:** Task 1's output determines which sub-procedure to run. Each sub-procedure produces the verdict-specific changes for this branch. Execute exactly one.

**Subsystem spec(s):** `plugins/dev-workflow-toolkit/skills/SPEC.md` (any skill changes live under this plugin)
**Key invariants from spec:** Depends on sub-procedure chosen — see each branch below.

**Adjacent specs:** None (all verdict-specific changes stay inside dev-workflow-toolkit).

**Files:** Depends on sub-procedure.

**Depends on:** Task 1 (verdict), Task 2 (doc updates — not strictly required, but ordering avoids re-running quality gate).

**Mixed-verdict escalation.** Before executing any branch, re-read the UPSTREAM file's "Verdict and rationale" section. If the rationale names two distinct kinds of change (e.g. "graft into brainstorming AND create a new skill"), escalate: add the `epic` label to #163, open child issues for each kind of change, stop this branch with Task 1 + Task 2's commits only (treat as Branch A for the remainder of the plan). Do NOT try to implement both in one branch.

```bash
# Mixed-verdict escalation commands
gh issue edit 163 --add-label epic
gh issue create --title "<child 1 summary>" --body "Part of #163 — <describe>" --label enhancement
gh issue create --title "<child 2 summary>" --body "Part of #163 — <describe>" --label enhancement
# Then skip to Task 4 with the Branch A path
```

#### Branch A — Do not adopt (no further implementation)

**Action:** None. Task 1 and Task 2 commits are the complete deliverable. Proceed to Task 4.

**Optional:** Add a single-line CHANGELOG entry under `plugins/dev-workflow-toolkit/CHANGELOG.md`'s `## Unreleased` section: `Evaluated karpathy-guidelines; not adopted — see skills/UPSTREAM-karpathy.md`. Decide at finishing-a-development-branch whether this warrants the CHANGELOG bump (probably no — it's a pure evaluation record with no user-facing plugin change).

#### Branch B — Graft specific phrasings

**Files:** Modify the specific SKILL.md / CLAUDE.md files named in UPSTREAM-karpathy.md's "Changes made" section. Typically 1-3 files, each with prose edits of 1-10 lines.

**Key invariants:**
- `dev-workflow-toolkit` SPEC.md INV-2 (Skill names are unique) — unaffected by prose edits
- INV-5 (Skill references use name, not path) — check that any cross-references in grafted prose follow this

**Action:**

1. For each graft named in UPSTREAM-karpathy.md, apply the specific edit with `Edit`. Quote the before/after in the commit message so review can see the compression or clarity win.
2. If a graft changes a skill's `description` field in frontmatter, run the corresponding triggering test in `plugins/dev-workflow-toolkit/tests/` first (TDD: update expectation → verify red → apply change → verify green). Most grafts won't touch frontmatter.
3. Update `plugins/dev-workflow-toolkit/CHANGELOG.md` `## Unreleased` with a bullet per graft. Add `<!-- bump: patch -->` comment in the Unreleased section.
4. Run `plugins/dev-workflow-toolkit/tests/run-all.sh`. All tests must pass.
5. Commit:
   ```bash
   git add plugins/dev-workflow-toolkit/skills/<affected>/SKILL.md plugins/dev-workflow-toolkit/CHANGELOG.md <any test files>
   git commit -m "feat(dev-workflow-toolkit): graft karpathy phrasings into <skills>"
   ```

#### Branch C — Refactor skill X

**Precondition:** Invoke `ux-design-agent` BEFORE touching the skill. The refactor changes how the skill guides agent behavior; UX design is required per the brainstorming UX evaluation.

```
Skill: ux-toolkit:ux-design-agent
Arguments: Refactoring skill <X> in dev-workflow-toolkit based on the verdict in
  plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md. Brief the agent on
  the current skill's behavioral role and the refactor target from UPSTREAM-karpathy.md.
```

**Files:** `plugins/dev-workflow-toolkit/skills/<X>/SKILL.md`, potentially `plugins/dev-workflow-toolkit/skills/SPEC.md` (if the refactor changes invariants), `plugins/dev-workflow-toolkit/tests/test_<X>*.py` (behavior tests).

**Key invariants:**
- INV-2 (unique skill names) — preserve the skill name
- INV-5 (references by name) — any internal references within the refactored SKILL.md must use skill names
- Any INV-N tied to the specific skill being refactored

**Action:**

1. Identify all behavior tests for the skill under `plugins/dev-workflow-toolkit/tests/`. Cite them in the commit message.
2. Per the UPSTREAM file's refactor description and the ux-design-agent output, update behavior-expectation tests FIRST (TDD).
3. Verify red: `plugins/dev-workflow-toolkit/tests/run-all.sh` — new tests must fail, old tests must still pass.
4. Apply the SKILL.md refactor.
5. Verify green: all tests pass, including the new/updated expectations.
6. If the refactor introduces or removes an INV-N or FAIL-N, update SPEC.md. Re-run `scripts/quality-gate.sh --check inv-numbering --path .` to confirm no numbering gaps.
7. Update `CHANGELOG.md` with the refactor description. Add `<!-- bump: minor -->`.
8. Commit:
   ```bash
   git add plugins/dev-workflow-toolkit/skills/<X>/SKILL.md plugins/dev-workflow-toolkit/tests/ plugins/dev-workflow-toolkit/CHANGELOG.md <SPEC.md if changed>
   git commit -m "refactor(dev-workflow-toolkit): restructure <X> skill based on karpathy evaluation"
   ```

#### Branch D — New compact skill

**Precondition:** Invoke `ux-design-agent` BEFORE creating the skill.

```
Skill: ux-toolkit:ux-design-agent
Arguments: Designing a new compact behavioral-guidelines skill in dev-workflow-toolkit
  based on the verdict in plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md.
  Brief on the triggering gap this skill fills and what principles it encapsulates.
```

**Files:**
- Create: `plugins/dev-workflow-toolkit/skills/<new-skill>/SKILL.md`
- Create: `plugins/dev-workflow-toolkit/tests/test_<new-skill>.py`
- Modify: `plugins/dev-workflow-toolkit/skills/SPEC.md` (if new INV-N / FAIL-N)
- Modify: `plugins/dev-workflow-toolkit/README.md` (skill-count footnote increments)

**Key invariants:**
- INV-2 (unique skill names) — name must not collide with any existing skill across all plugins. Check: `grep -r "^name:" plugins/*/skills/*/SKILL.md`
- INV-5 (references by name)
- INV-15 (GitHub projection) — if the new skill produces design/review/status artifacts, add it to `GITHUB_PROJECTION_SKILLS`
- skill-structure quality gate — SKILL.md needs YAML frontmatter with `name` matching directory

**Action:**

1. Collision check:
   ```bash
   grep -r "^name:" plugins/*/skills/*/SKILL.md | awk -F: '{print $3}' | sort -u
   ```
   Ensure the new name is absent.
2. Create the skill directory and SKILL.md. Content per UPSTREAM-karpathy.md's "Changes made" section and ux-design-agent output.
3. Write behavior tests FIRST (TDD): one triggering test + one behavior test per principle the skill covers.
4. Verify red.
5. Implement the SKILL.md body.
6. Verify green.
7. If adding INV-N/FAIL-N: update SPEC.md, renumber if needed, run `scripts/quality-gate.sh --check inv-numbering`.
8. Update README.md skill-count footnote. Re-run `scripts/quality-gate.sh --check doc-stats` to confirm.
9. Update CHANGELOG.md with `<!-- bump: minor -->` and a bullet describing the new skill.
10. Commit:
    ```bash
    git add plugins/dev-workflow-toolkit/skills/<new-skill>/ plugins/dev-workflow-toolkit/tests/test_<new-skill>.py plugins/dev-workflow-toolkit/CHANGELOG.md plugins/dev-workflow-toolkit/README.md plugins/dev-workflow-toolkit/skills/SPEC.md
    git commit -m "feat(dev-workflow-toolkit): add <new-skill> derived from karpathy evaluation"
    ```

---

### Task 4: Verification, signal assessment, and finishing transition

**Context:** Final gate before finishing-a-development-branch. Confirms tests pass, quality gate is green, UPSTREAM file is internally consistent, and captures any Approach-B follow-up signal for retrospective.

**Subsystem spec(s):** `plugins/dev-workflow-toolkit/skills/SPEC.md`
**Key invariants from spec:** None specific — this is a verification task.

**Adjacent specs:** None.

**Files:** Read-only verification; no files created/modified (except possibly the `.claude/turnover/` file if finishing-a-development-branch creates one).

**Depends on:** Tasks 1, 2, 3.

**Step 1: Run the full test suite**

```bash
cd /workspace/my-claude-plugins/.worktrees/feature/163-evaluate-karpathy
tests/run-all.sh
```

Expected: all tests pass. If any fail, do not proceed — debug root cause.

**Step 2: Run the full quality gate**

```bash
plugins/dev-workflow-toolkit/scripts/quality-gate.sh --path .
```

Expected: all structural checks pass. Blocking failures in `inv-numbering`, `skill-structure`, or `doc-structure` must be fixed before proceeding.

**Step 3: UPSTREAM consistency check**

Read `plugins/dev-workflow-toolkit/skills/UPSTREAM-karpathy.md`. Confirm:
- Verdict field in header matches the verdict explained in "Verdict and rationale"
- "Changes made" section matches what was actually committed on this branch (diff against base)
- "Signals for broader review" lists concrete citations, not vague references

If any inconsistency, return to Task 1 Step 8 and fix.

**Step 4: Assess Approach-B signal threshold**

Re-read UPSTREAM-karpathy.md's "Signals for broader review" section. Count distinct signal types that fired:
- Compression signal (≥3x ratio somewhere)
- Fragmentation signal (same guidance in ≥3 places)
- Conflict signal (contradictory pair)

If ≥2 distinct types fired, note this for retrospective. Do NOT file the issue here — retrospective is the right place per the design. Add a bullet to a session-scoped note or task to remind retrospective to file the follow-up.

**Step 5: Transition to finishing-a-development-branch**

Task 4 is the last task before branch integration. Invoke finishing-a-development-branch (it runs the documentation-standards validate-mode gate, creates the PR, invokes retrospective).

---

## GitHub projection

After this plan file is saved, post the task summary to issue #163:

```bash
gh issue comment 163 --body "## Implementation Plan
- [ ] Task 1: Execute the evaluation and produce UPSTREAM-karpathy.md
- [ ] Task 2: Apply approved documentation updates
- [ ] Task 3: Branch by verdict — apply verdict-specific implementation
- [ ] Task 4: Verification, signal assessment, and finishing transition

Plan: \`~/.claude/plans/2026-04-19-karpathy-evaluation-plan.md\`"
```

## Execution handoff

Plan complete and saved to `~/.claude/plans/2026-04-19-karpathy-evaluation-plan.md`. Proceeding with subagent-driven execution.

</details>

Closes #163