### PR TITLE
fix(quality-gate): elevate doc-stats mismatch from WARN to FAIL (#114)

### DIFF
--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,6 +3,12 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
+## Unreleased <!-- bump: patch -->
+
+### Fixed
+
+- **quality-gate doc-stats:** Stat mismatches now emit `FAIL` instead of `WARN` so CI blocks stale README counts from shipping (#114). Also registered `doc-stats` as a Step 7 structural check in `documentation-standards` so the finishing workflow runs it.
+
 ## v1.18.2
 
 ### Fixed

--- a/plugins/dev-workflow-toolkit/README.md
+++ b/plugins/dev-workflow-toolkit/README.md
@@ -126,7 +126,7 @@ cd plugins/dev-workflow-toolkit
 ./tests/run-all.sh
 ```
 
-**328 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
+**330 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
 - Structure — frontmatter validation, SPEC.md checks, project-init templates, setup-rag config, cross-plugin validation
 - Integration — skill loading, dependency resolution, trigger patterns, reference files
 - Quality gate — smoke tests, negative fixtures, doc-stats validation

--- a/plugins/dev-workflow-toolkit/scripts/quality_gate.py
+++ b/plugins/dev-workflow-toolkit/scripts/quality_gate.py
@@ -720,7 +720,7 @@ def check_doc_stats(results: Results, project_root: Path) -> None:
             else:
                 report(
                     results,
-                    "WARN",
+                    "FAIL",
                     "doc-stats",
                     f"{rel}: [^{label}] {check_name} claims {claimed}, actual {actual}",
                 )

--- a/plugins/dev-workflow-toolkit/skills/documentation-standards/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/documentation-standards/SKILL.md
@@ -114,6 +114,7 @@ Do NOT allow the branch to proceed to option presentation, PR creation, or merge
    ```bash
    ${CLAUDE_SKILL_DIR}/../../scripts/quality-gate.sh --check inv-numbering --path "$(git rev-parse --show-toplevel)"
    ${CLAUDE_SKILL_DIR}/../../scripts/quality-gate.sh --check doc-structure --path "$(git rev-parse --show-toplevel)"
+   ${CLAUDE_SKILL_DIR}/../../scripts/quality-gate.sh --check doc-stats --path "$(git rev-parse --show-toplevel)"
    ```
 
    Include structural check results alongside documentation gap analysis.

--- a/plugins/dev-workflow-toolkit/tests/test_quality_gate.py
+++ b/plugins/dev-workflow-toolkit/tests/test_quality_gate.py
@@ -369,7 +369,7 @@ class TestDocStats:
         assert "skill-count = 1" in result.stdout
 
     def test_wrong_skill_count(self, qg: str, fixture_dir: Path):
-        """Stat-check with wrong count warns but doesn't fail."""
+        """Stat-check with wrong count fails (#114 — was WARN, now FAIL)."""
         readme = fixture_dir / "plugins" / "test-plugin" / "README.md"
         readme.write_text(
             "# Test Plugin\n\n"
@@ -378,7 +378,7 @@ class TestDocStats:
             "[^stat-skill-count]: stat-check: skill-count\n"
         )
         result = run_qg(qg, "--check", "doc-stats", "--path", str(fixture_dir))
-        assert result.returncode == 0, "Stat mismatch should warn, not fail"
+        assert result.returncode != 0, "Stat mismatch must fail to block stale stats from shipping"
         assert "claims 5, actual 1" in result.stdout
 
     def test_unknown_check_name(self, qg: str, fixture_dir: Path):


### PR DESCRIPTION
## Summary

- **`quality_gate.py`:** Stat-check footnote mismatches now emit `FAIL` (was `WARN`). Stops stale README counts from silently shipping.
- **`documentation-standards` SKILL.md:** Added `doc-stats` to Step 7 structural checks alongside `inv-numbering` and `doc-structure`.
- **`README.md`:** Pre-existing drift caught by the new gate: `total-test-count` 328 → 330 (actual count).
- **`test_wrong_skill_count`:** Updated to assert FAIL (returncode != 0) instead of WARN.

Part of #166 (Q2 2026 issue queue cleanup sprint).

Closes #114

## Test Plan

- [x] Unit test flipped red → green
- [x] Full suite: 328 passed, 2 skipped
- [x] Quality gate: 87/87 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)