### PR TITLE
fix(requesting-code-review): mandate posting reviews to GitHub (#116, #142)

### DIFF
--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,6 +3,12 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
+## Unreleased <!-- bump: patch -->
+
+### Fixed
+
+- **`requesting-code-review`:** Mandate posting reviews to GitHub (#116, #142). Code-reviewer template now carries a MANDATORY-OUTPUT preamble when a PR number is provided, and SKILL.md positions itself as the canonical review flow versus the built-in `/review` command (which does not post to GitHub).
+
 ## v1.18.3
 
 ### Fixed

--- a/plugins/dev-workflow-toolkit/README.md
+++ b/plugins/dev-workflow-toolkit/README.md
@@ -126,7 +126,7 @@ cd plugins/dev-workflow-toolkit
 ./tests/run-all.sh
 ```
 
-**330 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
+**333 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
 - Structure — frontmatter validation, SPEC.md checks, project-init templates, setup-rag config, cross-plugin validation
 - Integration — skill loading, dependency resolution, trigger patterns, reference files
 - Quality gate — smoke tests, negative fixtures, doc-stats validation

--- a/plugins/dev-workflow-toolkit/skills/requesting-code-review/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/requesting-code-review/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: requesting-code-review
-description: Use when completing tasks, implementing major features, before merging to verify work meets requirements, or to review a specific PR by number
+description: Canonical review flow for this repo — review a PR by number and post findings to GitHub. Use when completing tasks, implementing major features, before merging to verify work meets requirements, or to review a specific PR. Prefer over the built-in /review command, which does not post to GitHub.
 ---
 
 # Requesting Code Review
 
-Dispatch code-reviewer subagent to catch issues before they cascade.
+Dispatch code-reviewer subagent to catch issues before they cascade, **and always post the review to GitHub** when a PR exists.
 
-**Core principle:** Review early, review often.
+**Core principle:** Review early, review often — and always post findings to the PR surface so the record is visible to collaborators (INV-15 GitHub Projection).
+
+> **This skill vs. built-in `/review`:** The Claude Code built-in `/review <PR#>` command produces an in-chat review but does NOT post to GitHub. When a PR review needs to be recorded on GitHub, use this skill (or explicitly call `gh pr review`/`gh pr comment` after `/review`). The two skills have overlapping purposes but only this one closes the loop on GitHub.
 
 ## When to Request Review
 

--- a/plugins/dev-workflow-toolkit/skills/requesting-code-review/code-reviewer.md
+++ b/plugins/dev-workflow-toolkit/skills/requesting-code-review/code-reviewer.md
@@ -2,13 +2,15 @@
 
 You are reviewing code changes for production readiness.
 
+> **MANDATORY OUTPUT:** If `{PR_NUMBER}` is set, you MUST post the review to GitHub before finishing. Displaying the review in chat alone is insufficient — the PR on GitHub is the canonical record. See "Post to PR" below.
+
 **Your task:**
 1. Review {WHAT_WAS_IMPLEMENTED}
 2. Compare against {PLAN_REFERENCE}
 3. Check code quality, architecture, testing
 4. Categorize issues by severity
 5. Assess production readiness
-6. If reviewing a PR, post findings and take the appropriate final action
+6. **If `{PR_NUMBER}` is set, post findings to GitHub AND take the appropriate final action** (see "Post to PR" section). Displaying locally alone is a bug.
 
 ## What Was Implemented
 

--- a/plugins/dev-workflow-toolkit/tests/test_integration.py
+++ b/plugins/dev-workflow-toolkit/tests/test_integration.py
@@ -724,3 +724,34 @@ class TestFinishingSquashMerge:
             "Step 5c must explain fast-forward detection behavior (#156)"
         )
 
+
+class TestRequestingCodeReviewPosting:
+    """#116 + #142: code-reviewer template must mandate posting to GitHub."""
+
+    def test_reviewer_template_mandates_github_posting(self, skills_dir: Path):
+        """Code-reviewer.md must have a MANDATORY-level instruction to post when PR_NUMBER is set."""
+        text = (skills_dir / "requesting-code-review" / "code-reviewer.md").read_text()
+        assert "MANDATORY" in text, (
+            "code-reviewer.md must mark posting as MANDATORY (#116)"
+        )
+        task_list_end = text.find("## What Was Implemented")
+        task_list_text = text[:task_list_end]
+        assert "post" in task_list_text.lower() and "PR_NUMBER" in task_list_text, (
+            "code-reviewer.md task list must include posting to PR (#116)"
+        )
+
+    def test_skill_description_prefers_over_builtin_review(self, skills_dir: Path):
+        """Skill description must position itself as the canonical posting flow vs. built-in /review."""
+        text = (skills_dir / "requesting-code-review" / "SKILL.md").read_text()
+        fm_end = text.find("\n---", 3)
+        fm = text[:fm_end]
+        assert "GitHub" in fm or "github" in fm.lower(), (
+            "requesting-code-review description must reference GitHub posting to distinguish it from built-in /review (#142)"
+        )
+
+    def test_skill_body_disambiguates_from_builtin_review(self, skills_dir: Path):
+        """SKILL.md must explicitly contrast itself with built-in /review."""
+        text = (skills_dir / "requesting-code-review" / "SKILL.md").read_text()
+        assert "/review" in text, (
+            "SKILL.md must reference the built-in /review command to disambiguate (#142)"
+        )


### PR DESCRIPTION
## Summary

- **`code-reviewer.md` template:** Added a MANDATORY-OUTPUT preamble — when `{PR_NUMBER}` is set, posting the review to GitHub is required, not optional.
- **`requesting-code-review` SKILL.md:** Frontmatter description and body now explicitly position this skill as the canonical repo review flow versus the built-in `/review` command (which produces in-chat output only).
- **3 new tests** lock in the posting contract and the disambiguation from built-in `/review`.

Context: The built-in Claude Code `/review <PR#>` lives outside this repo; we can't modify it. Both issues want reviews to land on GitHub PRs — this PR makes our skill (`requesting-code-review`) unambiguously the right tool for that, and sharpens its instructions so agents don't stop at in-chat display.

Part of #166 (Q2 2026 issue queue cleanup sprint).

Closes #116
Closes #142

## Test Plan

- [x] New tests: TestRequestingCodeReviewPosting (3 passed)
- [x] Full suite: 331 passed, 2 skipped
- [x] Quality gate: 87/87 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)