### PR TITLE
fix(sdd): cross-task context + parallel ordering + quantitative checks (#159, #153, #122)

### DIFF
--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,6 +3,15 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
+## Unreleased <!-- bump: patch -->
+
+### Fixed
+
+- **`subagent-driven-development`:** Three orchestration improvements (#166 tracking).
+  - **#159** — Spec-reviewer prompt now has a `Known Expected Breakage` field so the orchestrator can pass cross-task dependency context; the reviewer marks downstream breakage as "handled by Task N" instead of flagging it as a failure.
+  - **#153** — Parallel dispatch section now notes that commit ordering is nondeterministic when parallel tasks commit to the same branch; reviewers should expect logical-vs-commit ordering divergence.
+  - **#122** — New Step 5b verifies quantitative task criteria (line counts, size limits, etc.) before spec review; if targets are missed by >10%, a follow-up subagent is dispatched.
+
 ## v1.18.4
 
 ### Fixed

--- a/plugins/dev-workflow-toolkit/README.md
+++ b/plugins/dev-workflow-toolkit/README.md
@@ -126,7 +126,7 @@ cd plugins/dev-workflow-toolkit
 ./tests/run-all.sh
 ```
 
-**333 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
+**337 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
 - Structure — frontmatter validation, SPEC.md checks, project-init templates, setup-rag config, cross-plugin validation
 - Integration — skill loading, dependency resolution, trigger patterns, reference files
 - Quality gate — smoke tests, negative fixtures, doc-stats validation

--- a/plugins/dev-workflow-toolkit/skills/subagent-driven-development/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/subagent-driven-development/SKILL.md
@@ -42,7 +42,8 @@ echo "Verified: on branch $branch in $(pwd)"
 3. **Load subsystem context.** For each task, find the nearest SPEC.md to the task's target files. If one exists, prepend its key sections (Purpose, Invariants, Failure Modes) to the task context when dispatching. For cross-cutting tasks: include the full spec for the primary subsystem and only the Public Interface section from adjacent subsystems. If a task needs >2 specs, it crosses too many boundaries — split it before dispatching.
 4. **Dispatch task.** Fresh subagent (via Task tool) with full task text and context. For independent tasks, dispatch in parallel. For dependent tasks, wait.
 5. **Handle questions.** If the subagent asks questions, answer clearly before letting them proceed.
-6. **Spec review.** Dispatch spec compliance reviewer (./spec-reviewer-prompt.md). If issues found, dispatch fix subagent, then re-review.
+5b. **Verify quantitative criteria.** If the task specifies numeric targets (line counts, file counts, performance thresholds, size limits), check the implementer's output against them before review. If a target is missed by >10%, dispatch a focused follow-up subagent with the specific gap and the target before moving on. Skip this step if the task has no quantitative criteria.
+6. **Spec review.** Dispatch spec compliance reviewer (./spec-reviewer-prompt.md). **Populate the "Known Expected Breakage" field** with any cross-task dependencies — e.g., "Task 2 will update server.py to use the new session API; breakage at old call sites is expected and handled there." This prevents the reviewer from flagging intentional in-flight breakage as a Task N failure. If issues found, dispatch fix subagent, then re-review.
 7. **Quality review.** Dispatch code quality reviewer (./code-quality-reviewer-prompt.md). If issues found, dispatch fix subagent, then re-review.
 8. **Document review.** After both reviews pass, post a summary to the GitHub issue:
    ```bash
@@ -66,6 +67,8 @@ echo "Verified: on branch $branch in $(pwd)"
 Independent tasks can be dispatched simultaneously. The per-task review cycle (steps 6-7) runs after each implementer finishes, so reviews can also run in parallel across tasks.
 
 **Guard:** Never parallelize tasks that write to the same files — this is hidden coupling even if tasks aren't marked as dependent.
+
+**Commit ordering is nondeterministic.** When parallel tasks commit to the same branch, commit order depends on agent completion timing — logical ordering may not match commit ordering (e.g., docs referencing new code may commit before the code itself). This is safe when tasks have no file overlap; reviewers should expect the divergence. For strict logical commit ordering, use sequential dispatch.
 
 > For larger efforts, consider using agent teams (Teammate tool) for self-coordinating execution.
 

--- a/plugins/dev-workflow-toolkit/skills/subagent-driven-development/spec-reviewer-prompt.md
+++ b/plugins/dev-workflow-toolkit/skills/subagent-driven-development/spec-reviewer-prompt.md
@@ -18,6 +18,13 @@ Task tool (general-purpose):
 
     [From implementer's report]
 
+    ## Known Expected Breakage (cross-task context)
+
+    [From orchestrator. If Task N's scope intentionally breaks downstream call sites
+    that a later task will fix, describe them here. Example: "Task 2 will update
+    server.py to use the new session API; breakage at session.add_message() call sites
+    is expected and handled there, not a Task 1 finding." Leave blank if none.]
+
     ## CRITICAL: Do Not Trust the Report
 
     The implementer finished suspiciously quickly. Their report may be incomplete,
@@ -59,6 +66,11 @@ Task tool (general-purpose):
     - Are there undocumented divergences (different tech stack, architecture, or approach than specified)?
 
     **Verify by reading code, not by trusting report.**
+
+    **Expected breakage exception:** Findings that match "Known Expected Breakage"
+    above are NOT issues for this task — flag them as "handled by Task N" instead of
+    failing the review. Still report them in a separate line so the orchestrator can
+    confirm the downstream task still accounts for them.
 
     Report:
     - ✅ Spec compliant (if everything matches after code inspection)

--- a/plugins/dev-workflow-toolkit/tests/test_integration.py
+++ b/plugins/dev-workflow-toolkit/tests/test_integration.py
@@ -755,3 +755,48 @@ class TestRequestingCodeReviewPosting:
         assert "/review" in text, (
             "SKILL.md must reference the built-in /review command to disambiguate (#142)"
         )
+
+
+class TestSubagentDrivenDevelopmentContext:
+    """#159, #153, #122: spec reviewer context + parallel ordering + quantitative checks."""
+
+    def test_spec_reviewer_has_expected_breakage_field(self, skills_dir: Path):
+        """Spec reviewer template must accept cross-task dependency context (#159)."""
+        text = (skills_dir / "subagent-driven-development" / "spec-reviewer-prompt.md").read_text()
+        assert "Known Expected Breakage" in text, (
+            "spec-reviewer-prompt.md must have an Expected Breakage field so orchestrator can pass cross-task context (#159)"
+        )
+        assert "handled by Task" in text or "handled there" in text, (
+            "spec-reviewer-prompt.md must instruct reviewer how to mark cross-task findings (#159)"
+        )
+
+    def test_sdd_skill_instructs_populating_breakage_field(self, skills_dir: Path):
+        """SKILL.md Step 6 must instruct the orchestrator to populate the Expected Breakage field."""
+        text = (skills_dir / "subagent-driven-development" / "SKILL.md").read_text()
+        assert "Known Expected Breakage" in text or "Expected Breakage" in text, (
+            "SKILL.md must instruct orchestrator to populate the Expected Breakage field (#159)"
+        )
+
+    def test_sdd_parallel_commit_ordering_note(self, skills_dir: Path):
+        """SKILL.md parallel dispatch section must warn about nondeterministic commit ordering (#153)."""
+        text = (skills_dir / "subagent-driven-development" / "SKILL.md").read_text()
+        start = text.index("Parallel dispatch")
+        section = text[start:start + 1500]
+        assert "nondeterministic" in section.lower() or "order" in section.lower(), (
+            "Parallel dispatch section must discuss commit ordering nondeterminism (#153)"
+        )
+        assert "commit" in section.lower(), (
+            "Parallel dispatch section must reference commit ordering specifically (#153)"
+        )
+
+    def test_sdd_has_quantitative_criteria_step(self, skills_dir: Path):
+        """SKILL.md must have a step to verify quantitative task criteria before review (#122)."""
+        text = (skills_dir / "subagent-driven-development" / "SKILL.md").read_text()
+        assert "quantitative" in text.lower(), (
+            "SKILL.md must reference quantitative criteria check (#122)"
+        )
+        quant_pos = text.lower().index("quantitative")
+        spec_review_pos = text.index("Spec review.")
+        assert quant_pos < spec_review_pos, (
+            "Quantitative criteria check must appear before Spec review step (#122)"
+        )


### PR DESCRIPTION
## Summary

Three orchestration improvements to `subagent-driven-development`:

- **#159** — Spec-reviewer prompt now has a `Known Expected Breakage` field so the orchestrator can pass cross-task dependency context. The reviewer marks downstream breakage as "handled by Task N" instead of flagging it as a failure.
- **#153** — Parallel dispatch section documents nondeterministic commit ordering; reviewers should expect logical-vs-commit ordering divergence when parallel tasks commit to the same branch.
- **#122** — New Step 5b verifies quantitative task criteria (line counts, size limits, performance targets) before spec review. If targets are missed by >10%, a focused follow-up subagent is dispatched with the specific gap.

Part of #166 (Q2 2026 issue queue cleanup sprint).

Closes #159
Closes #153
Closes #122

## Test Plan

- [x] 4 new tests (`TestSubagentDrivenDevelopmentContext`)
- [x] Full suite: 335 passed, 2 skipped
- [x] Quality gate: 87/87 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)