### PR TITLE
fix(using-git-worktrees): branch from main + isolate Python env (#160, #120)

### DIFF
--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,6 +3,14 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
+## Unreleased <!-- bump: patch -->
+
+### Fixed
+
+- **`using-git-worktrees`:** Two worktree hygiene fixes (#166 tracking).
+  - **#120** — Worktrees now branch from `origin/<default-branch>` explicitly (detected via `git symbolic-ref`) instead of the current branch. Prevents add/add merge conflicts when two feature PRs each carry files from the other.
+  - **#160** — Setup phase now unsets `VIRTUAL_ENV` and exports `UV_LINK_MODE=copy` before running project setup. Isolates the worktree's Python environment from the parent and avoids hardlink failures in container/bind-mount filesystems.
+
 ## v1.18.5
 
 ### Fixed

--- a/plugins/dev-workflow-toolkit/README.md
+++ b/plugins/dev-workflow-toolkit/README.md
@@ -126,7 +126,7 @@ cd plugins/dev-workflow-toolkit
 ./tests/run-all.sh
 ```
 
-**337 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
+**340 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
 - Structure — frontmatter validation, SPEC.md checks, project-init templates, setup-rag config, cross-plugin validation
 - Integration — skill loading, dependency resolution, trigger patterns, reference files
 - Quality gate — smoke tests, negative fixtures, doc-stats validation

--- a/plugins/dev-workflow-toolkit/skills/using-git-worktrees/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/using-git-worktrees/SKILL.md
@@ -100,6 +100,8 @@ project=$(basename "$(git rev-parse --show-toplevel)")
 
 ### 2. Create Worktree
 
+New branches MUST be created from the repo's default branch (typically `main`) — not from whatever branch is currently checked out. Branching from a feature branch causes add/add merge conflicts when both branches land on `main` (#120).
+
 ```bash
 # Determine full path
 case $LOCATION in
@@ -111,14 +113,29 @@ case $LOCATION in
     ;;
 esac
 
-# Create worktree with new branch
-git worktree add "$path" -b "$BRANCH_NAME"
+# Detect the repo's default branch (main or master) and fetch latest from origin
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+git fetch origin "$DEFAULT_BRANCH" --quiet
+
+# Create worktree with new branch, always based on origin/<default-branch>
+git worktree add "$path" -b "$BRANCH_NAME" "origin/$DEFAULT_BRANCH"
 cd "$path"
 ```
 
 ### 3. Run Project Setup
 
-Auto-detect and run appropriate setup:
+Before invoking any build or dependency-install command, **isolate the worktree's environment** so it doesn't inherit the parent worktree's state (#160):
+
+```bash
+# Python: detach from parent repo's .venv so the worktree creates its own
+unset VIRTUAL_ENV
+
+# Container/bind-mount filesystems: avoid hardlink failures with uv
+export UV_LINK_MODE=copy
+```
+
+Then auto-detect and run appropriate setup:
 
 ```bash
 # Node.js
@@ -129,7 +146,8 @@ if [ -f Cargo.toml ]; then cargo build; fi
 
 # Python
 if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-if [ -f pyproject.toml ]; then poetry install; fi
+if [ -f pyproject.toml ] && command -v uv >/dev/null; then uv sync; fi
+if [ -f pyproject.toml ] && ! command -v uv >/dev/null; then poetry install; fi
 
 # Go
 if [ -f go.mod ]; then go mod download; fi

--- a/plugins/dev-workflow-toolkit/tests/test_integration.py
+++ b/plugins/dev-workflow-toolkit/tests/test_integration.py
@@ -800,3 +800,31 @@ class TestSubagentDrivenDevelopmentContext:
         assert quant_pos < spec_review_pos, (
             "Quantitative criteria check must appear before Spec review step (#122)"
         )
+
+
+class TestUsingGitWorktreesIsolation:
+    """#160 + #120: worktree creation must branch from default branch and isolate env."""
+
+    def test_worktree_branches_from_default_branch(self, skills_dir: Path):
+        """SKILL.md must branch from origin/<default-branch>, not current branch (#120)."""
+        text = (skills_dir / "using-git-worktrees" / "SKILL.md").read_text()
+        assert "symbolic-ref" in text or "DEFAULT_BRANCH" in text, (
+            "SKILL.md must detect the repo's default branch explicitly (#120)"
+        )
+        assert "origin/$DEFAULT_BRANCH" in text or "origin/main" in text, (
+            "SKILL.md must create worktree branch based on origin/<default-branch> (#120)"
+        )
+
+    def test_worktree_unsets_virtual_env(self, skills_dir: Path):
+        """SKILL.md must unset VIRTUAL_ENV before setup to avoid parent .venv bleedthrough (#160)."""
+        text = (skills_dir / "using-git-worktrees" / "SKILL.md").read_text()
+        assert "unset VIRTUAL_ENV" in text, (
+            "SKILL.md must unset VIRTUAL_ENV in setup phase to isolate worktree's Python env (#160)"
+        )
+
+    def test_worktree_sets_uv_link_mode_copy(self, skills_dir: Path):
+        """SKILL.md must set UV_LINK_MODE=copy to avoid hardlink failures in container envs (#160)."""
+        text = (skills_dir / "using-git-worktrees" / "SKILL.md").read_text()
+        assert "UV_LINK_MODE=copy" in text, (
+            "SKILL.md must export UV_LINK_MODE=copy for bind-mount/container environments (#160)"
+        )


### PR DESCRIPTION
## Summary

Two worktree hygiene fixes:

- **#120** — Worktrees now branch from `origin/<default-branch>` explicitly (detected via `git symbolic-ref`) instead of the current branch. Prevents add/add merge conflicts when two feature PRs each carry files originated from the other.
- **#160** — Setup phase now unsets `VIRTUAL_ENV` and exports `UV_LINK_MODE=copy` before running project setup. Isolates the worktree's Python environment from the parent and avoids hardlink failures in container/bind-mount filesystems.

Part of #166 (Q2 2026 issue queue cleanup sprint).

Closes #160
Closes #120

## Test Plan

- [x] 3 new tests (`TestUsingGitWorktreesIsolation`)
- [x] Full suite: 338 passed, 2 skipped
- [x] Quality gate: 87/87 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)