### PR TITLE
fix(writing-plans): file conflict detection + anti-pattern guidance (#157, #161)

### DIFF
--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,6 +3,14 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
+## Unreleased <!-- bump: patch -->
+
+### Fixed
+
+- **`writing-plans`:** Two plan-quality improvements (#166 tracking).
+  - **#157** — New File Conflict Detection section instructs the planner to scan `**Files:**` lists and add dependencies when two tasks share a file. Plans include an explicit `## File Conflicts` table when conflicts are found.
+  - **#161** — New Acceptance Criteria Anti-Patterns section warns against fragile count assertions tied to user-chosen names (`pytest -k pattern reports N tests`). Prefer name-list, whole-suite-count, or behavior assertions.
+
 ## v1.18.6
 
 ### Fixed

--- a/plugins/dev-workflow-toolkit/README.md
+++ b/plugins/dev-workflow-toolkit/README.md
@@ -126,7 +126,7 @@ cd plugins/dev-workflow-toolkit
 ./tests/run-all.sh
 ```
 
-**340 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
+**342 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
 - Structure — frontmatter validation, SPEC.md checks, project-init templates, setup-rag config, cross-plugin validation
 - Integration — skill loading, dependency resolution, trigger patterns, reference files
 - Quality gate — smoke tests, negative fixtures, doc-stats validation

--- a/plugins/dev-workflow-toolkit/skills/writing-plans/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/writing-plans/SKILL.md
@@ -147,6 +147,37 @@ Mark each task's dependencies explicitly. Independent tasks can be dispatched to
 ### Task 3: Integration tests   [Depends on: Task 1, Task 2]
 ```
 
+### File Conflict Detection (#157)
+
+Before marking tasks `[Independent]`, scan each task's `**Files:**` list. If two tasks modify the same file, they are NOT independent — the second must declare `[Depends on: Task N]`. Include a `## File Conflicts` section below the task list whenever a conflict is detected:
+
+```markdown
+## File Conflicts
+
+| File | Tasks | Resolution |
+|---|---|---|
+| `store.py` | Task 3, Task 6 | Task 6 depends on Task 3 |
+| `README.md` | Task 2, Task 5 | Task 5 depends on Task 2 |
+```
+
+If no conflicts exist, omit the section.
+
+## Acceptance Criteria Anti-Patterns (#161)
+
+**Do not assert numeric counts that depend on test names the implementer is free to choose.** Example of a fragile criterion:
+
+```
+uv run pytest tests/test_foo.py -k streaming reports 9 tests
+```
+
+If the implementer names a new test `test_tail_reads_mid_stream` (a perfectly good name that doesn't contain `streaming`), the assertion fails even though the feature is complete. Prefer one of:
+
+1. **Name-list assertions** — `tests test_a, test_b exist and pass`
+2. **Whole-suite count assertions** — `uv run pytest reports N passed` (not fragile to naming)
+3. **Behavior assertions** — `tail_session_log reads a mid-stream byte range` (independent of test organization)
+
+**Rule of thumb:** Count assertions are fine when counting something the plan itself enumerates (files created, invariants registered). They are fragile when counting things derived from names the implementer chooses.
+
 ## Remember
 - Exact file paths always
 - Complete code in plan (not "add validation")
@@ -156,7 +187,9 @@ Mark each task's dependencies explicitly. Independent tasks can be dispatched to
 - Include nearest SPEC.md path and key invariants in each task
 - For cross-cutting tasks: full spec for primary subsystem, Public Interface only for adjacent subsystems. If >2 specs are relevant, the task is too large — split it by subsystem boundary
 - Mark dependencies between tasks
+- Scan File Conflicts before marking any task `[Independent]` (#157)
 - Acceptance criteria = what must be TRUE = the tests
+- Avoid count assertions tied to user-chosen names — prefer name-list or whole-suite counts (#161)
 - Anchor tests to SPEC.md item IDs (INV-N, FAIL-N) with inline `# Tests INV-N` comments on declaration lines
 - DRY, YAGNI, TDD, frequent commits
 

--- a/plugins/dev-workflow-toolkit/tests/test_integration.py
+++ b/plugins/dev-workflow-toolkit/tests/test_integration.py
@@ -828,3 +828,30 @@ class TestUsingGitWorktreesIsolation:
         assert "UV_LINK_MODE=copy" in text, (
             "SKILL.md must export UV_LINK_MODE=copy for bind-mount/container environments (#160)"
         )
+
+
+class TestWritingPlansGuidance:
+    """#161 + #157: writing-plans must guide against fragile criteria and flag file conflicts."""
+
+    def test_file_conflict_detection_section(self, skills_dir: Path):
+        """SKILL.md must document File Conflict Detection before marking tasks Independent (#157)."""
+        text = (skills_dir / "writing-plans" / "SKILL.md").read_text()
+        assert "File Conflict" in text or "file conflict" in text.lower(), (
+            "SKILL.md must have a File Conflict Detection section (#157)"
+        )
+        # The guidance must instruct that two tasks modifying the same file are NOT independent
+        assert "Independent" in text and "same file" in text, (
+            "SKILL.md must state that tasks sharing a file cannot be marked Independent (#157)"
+        )
+
+    def test_acceptance_criteria_anti_patterns_section(self, skills_dir: Path):
+        """SKILL.md must warn against count assertions tied to user-chosen names (#161)."""
+        text = (skills_dir / "writing-plans" / "SKILL.md").read_text()
+        # Must mention the anti-pattern explicitly
+        assert "pytest" in text.lower() and "-k " in text, (
+            "SKILL.md must reference the -k pattern anti-pattern concretely (#161)"
+        )
+        # Must offer alternatives
+        assert "name-list" in text.lower() or "behavior assertion" in text.lower(), (
+            "SKILL.md must offer alternatives to fragile count assertions (#161)"
+        )


### PR DESCRIPTION
## Summary

Two plan-quality improvements:

- **#157** — New File Conflict Detection section instructs the planner to scan each task's `**Files:**` list and add dependencies when two tasks share a file. Plans now include an explicit `## File Conflicts` table when conflicts are detected, preventing accidental parallel dispatch of tasks that touch the same file.
- **#161** — New Acceptance Criteria Anti-Patterns section warns against fragile count assertions tied to user-chosen names (`pytest -k pattern reports N tests`). Prefer name-list assertions, whole-suite-count assertions, or behavior assertions.

Part of #166 (Q2 2026 issue queue cleanup sprint).

Closes #157
Closes #161

## Test Plan

- [x] 2 new tests (`TestWritingPlansGuidance`)
- [x] Full suite: 340 passed, 2 skipped
- [x] Quality gate: 87/87 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)