### PR TITLE
fix(brainstorming): recommended option first + ux-design supplement (#140, #132)

### DIFF
--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,6 +3,14 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
+## Unreleased <!-- bump: patch -->
+
+### Fixed
+
+- **`brainstorming`:** Two UX improvements (#166 tracking).
+  - **#140** — Recommended options must be listed first in every `AskUserQuestion` call; the UX design question now puts "No, do UX design (Recommended)" before the Skip option. Users opt out of recommendations, not into them.
+  - **#132** — When brainstorming Q&A has already decided UX content, pass the decided context to `ux-design-agent` so it supplements (design direction, visual system) rather than restates. Consider skipping `ux-design-agent` entirely if Q&A covered everything structural.
+
 ## v1.18.7
 
 ### Fixed

--- a/plugins/dev-workflow-toolkit/README.md
+++ b/plugins/dev-workflow-toolkit/README.md
@@ -126,7 +126,7 @@ cd plugins/dev-workflow-toolkit
 ./tests/run-all.sh
 ```
 
-**342 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
+**345 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
 - Structure — frontmatter validation, SPEC.md checks, project-init templates, setup-rag config, cross-plugin validation
 - Integration — skill loading, dependency resolution, trigger patterns, reference files
 - Quality gate — smoke tests, negative fixtures, doc-stats validation

--- a/plugins/dev-workflow-toolkit/skills/brainstorming/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/brainstorming/SKILL.md
@@ -79,6 +79,7 @@ You MUST create a task for each of these items and complete them in order:
 - If prior ideation exists, start from that context
 - Batch independent clarifying questions together using `AskUserQuestion` (up to 4) or grouped free-text in a single message
 - Use `AskUserQuestion` when you can propose good options; use free-text when questions are open-ended
+- **Recommended option must be listed first** in every `AskUserQuestion` call, with the `(Recommended)` suffix on the label. The user should have to actively opt out of the recommendation, not actively opt in (#140)
 - If you have enough context from the issue, prior ideation, or SPEC.md to draft design sections, present them alongside remaining questions rather than waiting
 - Focus on understanding: purpose, constraints, success criteria
 
@@ -122,9 +123,11 @@ UX design is always required unless both:
 
 **DO NOT** make exceptions because changes are viewed as "internal" or "infrastructure".
 
-**Evaluate whether UX design is needed.** If it is, use `AskUserQuestion` to ask: "This requires UX design. Skip?" with options "No, do UX design (Recommended)" and "Yes, skip to implementation planning". Batch this with design approval if in approval mode.
+**Evaluate whether UX design is needed.** If it is, use `AskUserQuestion` to ask: "This requires UX design. Skip?" with the **Recommended option listed first**: "No, do UX design (Recommended)" then "Yes, skip to implementation planning". Batch this with design approval if in approval mode.
 
 When UX design is required, use **ux-design-agent** (REQUIRED SUB-SKILL) to produce structured requirements, then continue to writing-plans. Otherwise, proceed directly to writing-plans.
+
+**Avoid re-deriving already-decided UX content (#132).** If the brainstorming Q&A has already resolved UX decisions in depth (layout approach, interaction patterns, copy, visual hierarchy), pass the decided context to `ux-design-agent` so it **supplements** rather than restates. Ask for the additive layer only: design direction, color/typography system, surface rules. If the Q&A already covered everything structural, consider skipping `ux-design-agent` and noting the coverage in the design doc.
 
 ## After the Design
 

--- a/plugins/dev-workflow-toolkit/tests/test_integration.py
+++ b/plugins/dev-workflow-toolkit/tests/test_integration.py
@@ -855,3 +855,38 @@ class TestWritingPlansGuidance:
         assert "name-list" in text.lower() or "behavior assertion" in text.lower(), (
             "SKILL.md must offer alternatives to fragile count assertions (#161)"
         )
+
+
+class TestBrainstormingRecommendedDefaults:
+    """#140 + #132: recommended option first + no UX duplication."""
+
+    def test_recommended_option_first_guidance(self, skills_dir: Path):
+        """SKILL.md must instruct that the Recommended option is listed first (#140)."""
+        text = (skills_dir / "brainstorming" / "SKILL.md").read_text()
+        assert "Recommended option must be listed first" in text or "Recommended option is listed first" in text, (
+            "SKILL.md must require Recommended option to be first in AskUserQuestion calls (#140)"
+        )
+
+    def test_ux_design_question_recommended_first(self, skills_dir: Path):
+        """The UX design question must list 'No, do UX design (Recommended)' before Skip."""
+        text = (skills_dir / "brainstorming" / "SKILL.md").read_text()
+        # The UX design question text should have Recommended option first
+        start = text.find("This requires UX design")
+        assert start != -1, "SKILL.md must ask the UX design question"
+        # In the 300 chars after, "No, do UX design" should appear before "Yes, skip"
+        section = text[start:start + 500]
+        recommended_pos = section.find("No, do UX design")
+        skip_pos = section.find("Yes, skip")
+        assert recommended_pos != -1 and skip_pos != -1, (
+            "SKILL.md must list both UX design options"
+        )
+        assert recommended_pos < skip_pos, (
+            "Recommended UX design option must appear before Skip option (#140)"
+        )
+
+    def test_ux_supplement_guidance_present(self, skills_dir: Path):
+        """SKILL.md must warn against re-deriving already-decided UX content (#132)."""
+        text = (skills_dir / "brainstorming" / "SKILL.md").read_text()
+        assert "supplement" in text.lower() and "decided" in text.lower(), (
+            "SKILL.md must instruct ux-design-agent to supplement decided content, not restate (#132)"
+        )


### PR DESCRIPTION
## Summary

- **#140** — Recommended options must be listed first in every `AskUserQuestion` call. The UX design question now puts "No, do UX design (Recommended)" before the Skip option. Users opt OUT of recommendations, not INTO them.
- **#132** — When brainstorming Q&A has already decided UX content, pass the decided context to `ux-design-agent` so it supplements (design direction, visual system) rather than restates. Consider skipping `ux-design-agent` entirely when Q&A covered everything structural.

Part of #166 (Q2 2026 issue queue cleanup sprint).

Closes #140
Closes #132

## Test Plan

- [x] 3 new tests (`TestBrainstormingRecommendedDefaults`)
- [x] Full suite: 343 passed, 2 skipped
- [x] Quality gate: 87/87 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)