### PR TITLE
fix(project-init): install pre-commit into .git/hooks, not Claude settings (#155)

### DIFF
--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,6 +3,12 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
+## Unreleased <!-- bump: patch -->
+
+### Fixed
+
+- **`project-init`:** Install pre-commit checks into `.git/hooks/pre-commit`, not `.claude/settings.json` (#155, #166 tracking). `preCommit` is not a valid Claude Code hook event, so the previous configuration failed silently. Audit checklist HOOK-1/HOOK-2 updated to verify git hooks instead. **ACTION:** if your project has `preCommit` entries in `.claude/settings.json`, remove them and install `check-version-bump.sh` / `check-changelog.sh` into `.git/hooks/pre-commit`.
+
 ## v1.18.8
 
 ### Fixed

--- a/plugins/dev-workflow-toolkit/README.md
+++ b/plugins/dev-workflow-toolkit/README.md
@@ -126,7 +126,7 @@ cd plugins/dev-workflow-toolkit
 ./tests/run-all.sh
 ```
 
-**345 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
+**347 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
 - Structure — frontmatter validation, SPEC.md checks, project-init templates, setup-rag config, cross-plugin validation
 - Integration — skill loading, dependency resolution, trigger patterns, reference files
 - Quality gate — smoke tests, negative fixtures, doc-stats validation

--- a/plugins/dev-workflow-toolkit/skills/project-init/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/project-init/SKILL.md
@@ -125,7 +125,19 @@ After scaffolding the base files, offer to set up release infrastructure:
 5. **Generate compute_version.py** — Python implementation using stdlib `json` + `tomllib` for reading, regex-based writes for TOML. Include `--ci` mode that reads bump type from `<!-- bump: TYPE -->` in CHANGELOG.md and rewrites `## Unreleased` to `## vX.Y.Z`. Tailored to the project's version file locations.
 6. **Generate release.yml** — GitHub Actions workflow: on push to main, detect plugins with `## Unreleased` sections, run `compute-version.sh --ci --update`, commit version bumps, create timestamp git tag (`YYYY-MM-DDTHHMMSSZ`), create GitHub Release with changelog content. Include `concurrency: { group: version-bump, cancel-in-progress: false }` to serialize parallel merges.
 7. **Generate ci.yml version-check job** — Pre-merge CI job that validates `bump:TYPE` PR label matches `<!-- bump: TYPE -->` changelog comment for changed plugins
-8. **Register hooks** — add `check-version-bump.sh` (validates `## Unreleased` + bump comment on source changes) and `check-changelog.sh` (validates bump comment when `## Unreleased` exists) to the project's Claude Code hook configuration
+8. **Register git pre-commit hook** — install `check-version-bump.sh` and `check-changelog.sh` as entries in `.git/hooks/pre-commit` (NOT in `.claude/settings.json`). These scripts inspect git staged files and belong in the git hook pipeline; placing them under Claude Code's `hooks` key fails because `preCommit` is not a valid Claude Code event (valid events: `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStop`, `UserPromptSubmit`). Write to `.git/hooks/pre-commit`:
+
+   ```bash
+   cat > .git/hooks/pre-commit <<'PRE_COMMIT_EOF'
+   #!/usr/bin/env bash
+   set -euo pipefail
+   bash "$(git rev-parse --show-toplevel)/scripts/check-version-bump.sh"
+   bash "$(git rev-parse --show-toplevel)/scripts/check-changelog.sh"
+   PRE_COMMIT_EOF
+   chmod +x .git/hooks/pre-commit
+   ```
+
+   `.git/hooks/` is not tracked by git — hook setup must be re-run on each clone. Document this in CONTRIBUTING.md and consider providing a `scripts/install-hooks.sh` helper for contributors.
 
 The release infrastructure is part of the initial commit with passing CI. The generated scripts are project-specific — the skill generates them based on the detected stack, not from templates.
 

--- a/plugins/dev-workflow-toolkit/skills/project-init/references/audit-checklist.md
+++ b/plugins/dev-workflow-toolkit/skills/project-init/references/audit-checklist.md
@@ -206,20 +206,20 @@ the project, and proposes fixes for failures.
 ### HOOK-1: check-version-bump hook
 
 - **Layer:** Hooks
-- **Check:** `check-version-bump.sh` registered as a Claude Code hook
-- **Expected:** Hook validates `## Unreleased` section and `<!-- bump: TYPE -->` comment on source changes
-- **Severity when failing:** OUTDATED
-- **Remediation:** Register check-version-bump.sh in Claude Code hook configuration
-- **Since:** v1.9.0 (updated v1.14.0)
+- **Check:** `check-version-bump.sh` invoked from `.git/hooks/pre-commit` (NOT from `.claude/settings.json`)
+- **Expected:** Git pre-commit hook validates `## Unreleased` section and `<!-- bump: TYPE -->` comment on source changes. Claude Code's `hooks` key does not support a `preCommit` event, so registering there silently fails (#155).
+- **Severity when failing:** OUTDATED | DRIFT
+- **Remediation:** Remove any `preCommit`-keyed entry from `.claude/settings.json` and install `check-version-bump.sh` into `.git/hooks/pre-commit` instead (project-init Step 8).
+- **Since:** v1.9.0 (updated v1.18.x for #155)
 
 ### HOOK-2: check-changelog hook
 
 - **Layer:** Hooks
-- **Check:** `check-changelog.sh` registered as a Claude Code hook
-- **Expected:** Hook validates bump comment presence when `## Unreleased` section exists
-- **Severity when failing:** OUTDATED
-- **Remediation:** Register check-changelog.sh in Claude Code hook configuration
-- **Since:** v1.9.0 (updated v1.14.0)
+- **Check:** `check-changelog.sh` invoked from `.git/hooks/pre-commit` (NOT from `.claude/settings.json`)
+- **Expected:** Git pre-commit hook validates bump comment presence when `## Unreleased` section exists.
+- **Severity when failing:** OUTDATED | DRIFT
+- **Remediation:** Remove any `preCommit`-keyed entry from `.claude/settings.json` and install `check-changelog.sh` into `.git/hooks/pre-commit` instead (project-init Step 8).
+- **Since:** v1.9.0 (updated v1.18.x for #155)
 
 ### HOOK-3: Quality gate SessionStart hook
 

--- a/plugins/dev-workflow-toolkit/tests/test_integration.py
+++ b/plugins/dev-workflow-toolkit/tests/test_integration.py
@@ -890,3 +890,31 @@ class TestBrainstormingRecommendedDefaults:
         assert "supplement" in text.lower() and "decided" in text.lower(), (
             "SKILL.md must instruct ux-design-agent to supplement decided content, not restate (#132)"
         )
+
+
+class TestProjectInitGitHooks:
+    """#155: project-init must wire pre-commit hooks via .git/hooks/, not .claude/settings.json."""
+
+    def test_skill_uses_git_hooks_not_claude_settings(self, skills_dir: Path):
+        """SKILL.md must explicitly NOT register pre-commit scripts via Claude Code hooks (#155)."""
+        text = (skills_dir / "project-init" / "SKILL.md").read_text()
+        assert ".git/hooks/pre-commit" in text, (
+            "SKILL.md must install pre-commit checks into .git/hooks/pre-commit (#155)"
+        )
+        assert "preCommit" in text and "not a valid" in text.lower(), (
+            "SKILL.md must call out that preCommit is not a valid Claude Code hook event (#155)"
+        )
+
+    def test_audit_checklist_reflects_git_hook_expectation(self, plugin_root: Path):
+        """Audit checklist HOOK-1 + HOOK-2 must check for git pre-commit hooks, not Claude hooks (#155)."""
+        path = plugin_root / "skills" / "project-init" / "references" / "audit-checklist.md"
+        text = path.read_text()
+        hook1 = text[text.index("### HOOK-1:"):text.index("### HOOK-2:")]
+        assert ".git/hooks/pre-commit" in hook1, (
+            "HOOK-1 check must verify .git/hooks/pre-commit, not .claude/settings.json (#155)"
+        )
+        hook2_start = text.index("### HOOK-2:")
+        hook2 = text[hook2_start:hook2_start + 800]
+        assert ".git/hooks/pre-commit" in hook2, (
+            "HOOK-2 check must verify .git/hooks/pre-commit, not .claude/settings.json (#155)"
+        )


### PR DESCRIPTION
## Summary

`preCommit` is not a valid Claude Code hook event (valid: `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStop`, `UserPromptSubmit`). Placing `check-version-bump.sh` under `.claude/settings.json`'s `hooks` key fails silently.

- **Step 8** now writes `.git/hooks/pre-commit` with `chmod +x` and shells out to `check-version-bump.sh` + `check-changelog.sh`.
- **Audit checklist HOOK-1/HOOK-2** updated to verify git hooks; remediation steps cover existing projects carrying stale `preCommit` entries.
- **CHANGELOG ACTION marker** instructs consumers to migrate.

Part of #166 (Q2 2026 issue queue cleanup sprint).

Closes #155

## Test Plan

- [x] 2 new tests (`TestProjectInitGitHooks`)
- [x] Full suite: 345 passed, 2 skipped
- [x] Quality gate: 87/87 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)