### PR TITLE
fix(codify-subsystem): support top-level modules, not just directories (#148)

### DIFF
--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,6 +3,12 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
+## Unreleased <!-- bump: patch -->
+
+### Fixed
+
+- **`codify-subsystem`:** Support top-level modules, not just directories (#148, #166 tracking). Frontmatter description, "When to Use" list, and new "Target Types" section cover single-file targets (`store.py`, `server.py`, etc.) with two placement options: sibling `module.SPEC.md` or promoted `module/SPEC.md`. Step 1 now handles both file and directory paths.
+
 ## v1.18.9
 
 ### Fixed

--- a/plugins/dev-workflow-toolkit/README.md
+++ b/plugins/dev-workflow-toolkit/README.md
@@ -126,7 +126,7 @@ cd plugins/dev-workflow-toolkit
 ./tests/run-all.sh
 ```
 
-**347 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
+**350 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
 - Structure — frontmatter validation, SPEC.md checks, project-init templates, setup-rag config, cross-plugin validation
 - Integration — skill loading, dependency resolution, trigger patterns, reference files
 - Quality gate — smoke tests, negative fixtures, doc-stats validation

--- a/plugins/dev-workflow-toolkit/skills/codify-subsystem/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/codify-subsystem/SKILL.md
@@ -1,25 +1,35 @@
 ---
 name: codify-subsystem
-description: Use when a subsystem directory needs a SPEC.md — analyzes code, interviews the developer about invariants and failure modes, and produces a machine-readable specification
+description: Use when a subsystem directory OR a top-level module needs a SPEC.md — analyzes code, interviews the developer about invariants and failure modes, and produces a machine-readable specification
 ---
 
 # Codify Subsystem
 
 ## Overview
 
-Create or update a SPEC.md for a subsystem directory. Analyzes the code,
-interviews the developer about purpose, invariants, and failure modes,
-then produces a specification that agents load when working on that subsystem.
+Create or update a SPEC.md for a subsystem — either a **directory** that groups related files, or a **top-level module** that is a single high-value source file (e.g., `store.py`, `server.py`). Analyzes the code, interviews the developer about purpose, invariants, and failure modes, then produces a specification that agents load when working on that subsystem.
 
-**Announce at start:** "I'm using the codify-subsystem skill to create a specification for [directory]."
+**Announce at start:** "I'm using the codify-subsystem skill to create a specification for [target]."
 
 ## When to Use
 
 - A directory has 3+ source files and no SPEC.md
+- A **top-level module** is frequently modified (e.g., `store.py`, `server.py`, `api.py`) and lacks a SPEC.md (#148)
 - A new feature directory is created
 - An agent encounters a subsystem it doesn't understand
 - After significant refactoring that changes a subsystem's invariants
 - During onboarding to document existing subsystems
+
+## Target Types (#148)
+
+The skill accepts either target type:
+
+- **Directory target** — `src/fetcher/` → produces `src/fetcher/SPEC.md`. Default for multi-file subsystems.
+- **File target** — `gist_story_ranker/store.py` → produces a module-level spec. Two placement options:
+  1. **Sibling spec** — `gist_story_ranker/store.SPEC.md` (same directory, file-scoped). Simpler; preserves module layout.
+  2. **Promoted directory** — move the module into `gist_story_ranker/store/` (with `__init__.py` re-exporting), then `gist_story_ranker/store/SPEC.md`. Preferred when the module is outgrowing a single file.
+
+Ask the user which placement to use when the target is a file. Default to **sibling spec** unless the module is clearly growing.
 
 ## Checklist
 
@@ -37,8 +47,10 @@ You MUST complete these steps in order:
 
 ### Step 1: Identify Target
 
-Ask the user which directory to codify, or accept the path they provided.
-Confirm the directory exists and list its files.
+Ask the user which directory OR file to codify, or accept the path they provided.
+
+- **If the path is a directory:** Confirm it exists and list its files.
+- **If the path is a single source file:** Confirm the file exists and ask which placement to use (see "Target Types" above): sibling `module.SPEC.md` or promote to `module/` directory. The rest of the process is identical; read the single file in Step 2 instead of a directory.
 
 ### Step 1b: Check for Parent SPEC.md
 
@@ -64,7 +76,7 @@ Step 6 (Update Subsystem Map).
 
 ### Step 2: Analyze Code
 
-Read all source files in the directory. Identify:
+Read the target source. For a directory target, read all source files; for a file target, read the one module (plus its tests). Identify:
 - Entry points and public API
 - Internal data flow
 - Dependencies (imports, external calls)

--- a/plugins/dev-workflow-toolkit/tests/test_integration.py
+++ b/plugins/dev-workflow-toolkit/tests/test_integration.py
@@ -918,3 +918,40 @@ class TestProjectInitGitHooks:
         assert ".git/hooks/pre-commit" in hook2, (
             "HOOK-2 check must verify .git/hooks/pre-commit, not .claude/settings.json (#155)"
         )
+
+
+class TestCodifySubsystemTopLevel:
+    """#148: codify-subsystem must support top-level modules, not just directories."""
+
+    def test_description_mentions_module(self, skills_dir: Path):
+        """Frontmatter description must mention top-level modules (#148)."""
+        text = (skills_dir / "codify-subsystem" / "SKILL.md").read_text()
+        end = text.find("\n---", 3)
+        fm = text[:end]
+        assert "module" in fm.lower(), (
+            "codify-subsystem description must mention top-level modules as a target type (#148)"
+        )
+
+    def test_target_types_section_describes_file_target(self, skills_dir: Path):
+        """SKILL.md must have a Target Types section describing file targets with placement options (#148)."""
+        text = (skills_dir / "codify-subsystem" / "SKILL.md").read_text()
+        assert "Target Types" in text, (
+            "SKILL.md must have a Target Types section documenting directory-vs-file targets (#148)"
+        )
+        target_section = text[text.index("Target Types"):text.index("Target Types") + 2000]
+        assert "Sibling spec" in target_section or "sibling" in target_section.lower(), (
+            "Target Types must describe sibling SPEC placement (#148)"
+        )
+        assert "Promoted directory" in target_section or "promote" in target_section.lower(), (
+            "Target Types must describe promoted-directory placement (#148)"
+        )
+
+    def test_step_1_accepts_file_paths(self, skills_dir: Path):
+        """Step 1 must handle file-target paths, not only directory paths (#148)."""
+        text = (skills_dir / "codify-subsystem" / "SKILL.md").read_text()
+        step1_start = text.index("### Step 1: Identify Target")
+        step1_end = text.index("### Step 1b")
+        step1 = text[step1_start:step1_end]
+        assert "file" in step1.lower() and "directory" in step1.lower(), (
+            "Step 1 must handle both file and directory targets (#148)"
+        )


### PR DESCRIPTION
## Summary

`codify-subsystem` previously targeted directories only. High-value single files like `store.py` / `server.py` / `api.py` fell through and ended up without spec coverage despite being the most-modified modules.

- Frontmatter description updated to mention module targets.
- New **Target Types** section documents two placement options for file targets: sibling `module.SPEC.md` (default) or promoted `module/` directory.
- "When to Use" list now includes top-level modules.
- Step 1 and Step 2 handle both file and directory targets.

Part of #166 (Q2 2026 issue queue cleanup sprint — final PR in the sprint).

Closes #148

## Test Plan

- [x] 3 new tests (`TestCodifySubsystemTopLevel`)
- [x] Full suite: 348 passed, 2 skipped
- [x] Quality gate: 87/87 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)