### PR TITLE
feat(subagent-driven-development): add pre-completion quality gate (#145)

### DIFF
--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -7,7 +7,7 @@ read this file and apply retroactive actions marked with **ACTION**.
 
 ### Changed
 
-- **`subagent-driven-development`:** Implementer subagents now run tests/lint/format with fresh output as evidence before reporting completion (#145). Pre-Report Gate added to `implementer-prompt.md`; new red-flag in `SKILL.md`; enforced by new INV-21 and FAIL-17 in `plugins/dev-workflow-toolkit/skills/SPEC.md`.
+- **`subagent-driven-development`:** Implementer subagents now run tests/lint/format with fresh output as evidence before reporting completion (#145). Pre-Report Gate added to `implementer-prompt.md`; new red-flag in `SKILL.md`; enforced by new INV-21 and FAIL-17 in SPEC.md.
 
 ### Fixed
 

--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -5,6 +5,10 @@ read this file and apply retroactive actions marked with **ACTION**.
 
 ## Unreleased <!-- bump: patch -->
 
+### Changed
+
+- **`subagent-driven-development`:** Implementer subagents now run tests/lint/format with fresh output as evidence before reporting completion (#145). Pre-Report Gate added to `implementer-prompt.md`; new red-flag in `SKILL.md`; enforced by new INV-21 and FAIL-17 in `plugins/dev-workflow-toolkit/skills/SPEC.md`.
+
 ### Fixed
 
 - **`codify-subsystem`:** Support top-level modules, not just directories (#148, #166 tracking). Frontmatter description, "When to Use" list, and new "Target Types" section cover single-file targets (`store.py`, `server.py`, etc.) with two placement options: sibling `module.SPEC.md` or promoted `module/SPEC.md`. Step 1 now handles both file and directory paths.

--- a/plugins/dev-workflow-toolkit/skills/SPEC.md
+++ b/plugins/dev-workflow-toolkit/skills/SPEC.md
@@ -113,7 +113,7 @@ lifecycle points (plan summaries, progress updates, review findings).
 | FAIL-14 | Shell cwd unusable after `git worktree remove` | Current worktree was removed while the shell's cwd was inside it | Step 6 resolves main worktree and `cd`s there before removing the current worktree (#149) |
 | FAIL-15 | `gh pr merge --delete-branch` reports "main is already used by worktree" | Running `gh pr merge --delete-branch` from a worktree triggers a conflicting `git checkout main` | Step 5c detects worktree context, drops `--delete-branch`, and deletes the remote branch via `gh api` (#162) |
 | FAIL-16 | Squash merge preserved all individual commits on main | GitHub fast-forwards rebased branches even when `--squash` is requested | Step 5c checks `git merge-base --is-ancestor` before squashing and warns when fast-forward is imminent (#156) |
-| FAIL-17 | Implementer reports completion without running tests/lint/format | Pre-Report Gate missing from `implementer-prompt.md` or subagent ignored it | Ensure `implementer-prompt.md` contains the Pre-Report Gate section; enforce via red-flag line in `subagent-driven-development/SKILL.md` |
+| FAIL-17 | Implementer reports completion without running tests/lint/format | Pre-Report Gate missing from `implementer-prompt.md` or subagent ignored it | Re-dispatch implementer with explicit reference to the Pre-Report Gate in `implementer-prompt.md`; reject the completion claim until fresh test/lint/format output is pasted |
 
 ## Decision Framework
 
@@ -148,6 +148,7 @@ INV-17: reasoning-required — verified during code review of SKILL.md turnover 
 INV-18: structural — enforced by `test_inv18_no_fail_on_error_flag` (scans SKILL.md for forbidden flag).
 INV-19: structural — enforced by `test_inv19_worktree_aware_merge` (scans Step 5c for detection + API cleanup).
 INV-20: reasoning-required — verified by `test_inv20_fast_forward_detection` (scans Step 5c for merge-base check) and during code review.
+INV-21: reasoning-required — verified by presence of the `## Pre-Report Gate` section in `subagent-driven-development/implementer-prompt.md` during code review; candidate for a string-presence structural test in a follow-up.
 
 Skills are additionally validated via subagent pressure testing — see `/skill-creator`.
 

--- a/plugins/dev-workflow-toolkit/skills/SPEC.md
+++ b/plugins/dev-workflow-toolkit/skills/SPEC.md
@@ -81,6 +81,7 @@ Skills compose into a development workflow graph. The primary flow is:
 | INV-18 | Skill prompts must only reference `gh` CLI flags that exist in currently-supported `gh` versions; verified by string-absence tests | structural | Prevents agent detours when `gh` rejects unknown flags; enforced by `test_inv18_no_fail_on_error_flag` |
 | INV-19 | `finishing-a-development-branch` Step 5c detects worktree context and omits `--delete-branch` when inside a worktree, cleaning up the remote branch via `gh api` instead | structural | `gh pr merge --delete-branch` fails from worktrees because its post-merge `git checkout main` collides with the main worktree |
 | INV-20 | `finishing-a-development-branch` Step 5c checks for fast-forward topology (`git merge-base --is-ancestor main HEAD`) before squashing and warns the user | reasoning-required | GitHub silently fast-forwards rebased branches even when `--squash` is requested, defeating the squash-merge intent |
+| INV-21 | Implementer subagents dispatched by `subagent-driven-development` run tests, lint, and format before reporting completion, and paste fresh command output as evidence | reasoning-required | Shifts quality enforcement left — reviewers catch meaningful issues instead of basic compilation/lint failures; prevents wasted review cycles |
 
 **Enforcement classification:**
 - **structural** — enforced by test suite, gitignore structure, or directory convention; pattern-matchable
@@ -112,6 +113,7 @@ lifecycle points (plan summaries, progress updates, review findings).
 | FAIL-14 | Shell cwd unusable after `git worktree remove` | Current worktree was removed while the shell's cwd was inside it | Step 6 resolves main worktree and `cd`s there before removing the current worktree (#149) |
 | FAIL-15 | `gh pr merge --delete-branch` reports "main is already used by worktree" | Running `gh pr merge --delete-branch` from a worktree triggers a conflicting `git checkout main` | Step 5c detects worktree context, drops `--delete-branch`, and deletes the remote branch via `gh api` (#162) |
 | FAIL-16 | Squash merge preserved all individual commits on main | GitHub fast-forwards rebased branches even when `--squash` is requested | Step 5c checks `git merge-base --is-ancestor` before squashing and warns when fast-forward is imminent (#156) |
+| FAIL-17 | Implementer reports completion without running tests/lint/format | Pre-Report Gate missing from `implementer-prompt.md` or subagent ignored it | Ensure `implementer-prompt.md` contains the Pre-Report Gate section; enforce via red-flag line in `subagent-driven-development/SKILL.md` |
 
 ## Decision Framework
 

--- a/plugins/dev-workflow-toolkit/skills/subagent-driven-development/SKILL.md
+++ b/plugins/dev-workflow-toolkit/skills/subagent-driven-development/SKILL.md
@@ -81,6 +81,7 @@ Independent tasks can be dispatched simultaneously. The per-task review cycle (s
 ## Red Flags
 
 - Never start implementation on main/master branch without explicit user consent
+- Never let implementer report completion without the pre-report gate (tests, lint, format all pass with fresh evidence)
 - Never skip reviews (spec compliance OR code quality)
 - Never proceed with unfixed issues — reviewer found issues means fix then re-review
 - Never make subagent read plan file (provide full text instead)

--- a/plugins/dev-workflow-toolkit/skills/subagent-driven-development/implementer-prompt.md
+++ b/plugins/dev-workflow-toolkit/skills/subagent-driven-development/implementer-prompt.md
@@ -96,6 +96,7 @@ Task tool (general-purpose):
     - Did I remove only imports/variables/functions that my changes made unused, leaving pre-existing dead code in place?
 
     **Testing:**
+    - Did I run the Pre-Report Gate commands (tests, lint, format) after my last edit and paste the output?
     - Do tests actually verify behavior (not just mock behavior)?
     - Did I follow TDD if required?
     - Are tests comprehensive?
@@ -106,7 +107,7 @@ Task tool (general-purpose):
 
     When done, report:
     - What you implemented
-    - What you tested and test results
+    - Pre-Report Gate evidence: fresh test/lint/format command output pasted verbatim (or "no tool detected" per category)
     - Files changed
     - Self-review findings (if any)
     - Plan divergences (any deviations from specified approach/tech stack, with rationale — or "None")

--- a/plugins/dev-workflow-toolkit/skills/subagent-driven-development/implementer-prompt.md
+++ b/plugins/dev-workflow-toolkit/skills/subagent-driven-development/implementer-prompt.md
@@ -43,7 +43,7 @@ Task tool (general-purpose):
     Once you're clear on requirements:
     1. Implement exactly what the task specifies
     2. Write tests (following TDD if task says to)
-    3. Verify implementation works
+    3. Verify implementation works (Pre-Report Gate below is mandatory)
     4. Commit your work
     5. Self-review (see below)
     6. Report back
@@ -52,6 +52,27 @@ Task tool (general-purpose):
 
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.
     It's always OK to pause and clarify. Don't guess or make assumptions.
+
+    ## Pre-Report Gate
+
+    **NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE.**
+
+    Before self-review and before reporting back, you MUST:
+
+    1. Run the project's test suite
+    2. Run the linter
+    3. Run the formatter
+    4. Fix any failures (tests, lint, or format violations)
+    5. Paste the fresh command output in your report as evidence
+
+    **Command detection order:**
+    1. Check `CONTRIBUTING.md` for project-documented test/lint/format commands
+    2. Check the nearest `SPEC.md` for subsystem-documented commands
+    3. Auto-detect from project files: `pyproject.toml` → `pytest`, `ruff check`, `ruff format`; `package.json` → `npm test`, `eslint`, `prettier`; `go.mod` → `go test ./...`, `golangci-lint run`, `gofmt -w`; `Cargo.toml` → `cargo test`, `cargo clippy`, `cargo fmt`
+
+    If no tool is detected for a category (e.g., no linter configured), record "no tool detected" for that step and proceed — do not invent a failure.
+
+    **This gate is non-negotiable.** Do not report completion with any failing step. Do not substitute "I believe the tests pass" for actual command output. Fresh output means executed *after* your most recent edit.
 
     ## Before Reporting Back: Self-Review
 


### PR DESCRIPTION
## Summary

- Adds a mandatory **Pre-Report Gate** to the implementer subagent prompt: tests, lint, and format must pass with fresh command output as evidence before completion is claimed
- Shifts quality enforcement left — from the code-quality reviewer (reactive) to the implementer (preventive)
- New invariant **INV-21** and failure mode **FAIL-17** added to `plugins/dev-workflow-toolkit/skills/SPEC.md`

## Test Plan

- [x] Full test suite passes (348 passed, 2 skipped) via `tests/run-all.sh`
- [x] Quality gate passes (87 checks, all green) — INV-1..21 and FAIL-1..17 sequential with no duplicates
- [x] `skill-structure` validates the modified `subagent-driven-development/SKILL.md`
- [ ] Manual smoke: dispatch a toy implementer subagent with the new prompt and confirm it runs the gate and pastes output (follow-up, not a blocker)

## Review Artifacts

- Design summary: [issue #145 comment](https://github.com/stvhay/my-claude-plugins/issues/145#issuecomment-4277052361)
- Plan summary: [issue #145 comment](https://github.com/stvhay/my-claude-plugins/issues/145#issuecomment-4277058786)
- Spec + code-quality review: [issue #145 comment](https://github.com/stvhay/my-claude-plugins/issues/145#issuecomment-4277073742)

<details><summary>Implementation Plan</summary>

# Subagent Pre-Completion Quality Gate Implementation Plan

**Issue:** #145
**Design:** `.claude/plans/2026-04-19-subagent-pre-completion-gate-design.md`

**Goal:** Add a mandatory Pre-Report Gate to the implementer subagent prompt so tests, lint, and format all pass with fresh evidence before completion is claimed.

**Architecture:** Surgical text change to `subagent-driven-development/implementer-prompt.md` (primary), supporting edits to that skill's `SKILL.md` (red-flag), `plugins/dev-workflow-toolkit/skills/SPEC.md` (new INV-21 + FAIL-17 + traceability), and `plugins/dev-workflow-toolkit/CHANGELOG.md` (entry under existing Unreleased section).

**Acceptance criteria (all met):**
- Pre-Report Gate section in `implementer-prompt.md`
- Step 3 of "Your Job" references the gate
- Testing self-review bullet reinforces the gate
- Report Format requires fresh evidence pasted verbatim
- Red-flag line in subagent-driven-development SKILL.md
- INV-21 + FAIL-17 + traceability line in dev-workflow-toolkit SPEC.md
- CHANGELOG patch entry under existing Unreleased
- Quality-gate structural checks pass

**Commits:**
- `e869fa5` feat: initial Pre-Report Gate implementation (4 files)
- `be9b9e4` fix: reinforce gate after code-quality review (self-review bullet, Report Format evidence field, INV-21 traceability, FAIL-17 recovery wording, changelog path normalization)

</details>

Closes #145