### PR TITLE
feat(dev-workflow-toolkit): post-edit formatter + pre-commit linter hooks (#146)

### DIFF
--- a/plugins/dev-workflow-toolkit/CHANGELOG.md
+++ b/plugins/dev-workflow-toolkit/CHANGELOG.md
@@ -3,11 +3,13 @@
 Agent-focused changelog. When a new version of this plugin is installed,
 read this file and apply retroactive actions marked with **ACTION**.
 
-## Unreleased <!-- bump: patch -->
+## Unreleased <!-- bump: minor -->
 
 ### Added
 
 - `docs/headless-patterns.md` — reference doc covering four `claude -p` headless-mode patterns (CI failure triage, post-merge cleanup, release tagging, batch lint/format). Linked from the README's `## Documentation` section.
+- **Post-edit formatter hook** (`hooks/post-edit-formatter.sh`) — `PostToolUse` on `Edit`/`Write`. Detects the project's toolchain (pyproject.toml, package.json, go.mod, Cargo.toml) and formats the touched file with ruff/black, prettier, gofmt, or rustfmt. Silent when no toolchain is detected.
+- **Pre-commit linter hook** (`hooks/pre-commit-linter.sh`) — `PreToolUse` on `Bash`. When the Bash command contains `git commit`, runs the project linter (ruff/flake8, eslint, golangci-lint/gofmt, cargo clippy) on staged files only. Exits 2 to block the commit on any failure; silent when no toolchain is detected.
 
 ## v1.18.11
 

--- a/plugins/dev-workflow-toolkit/README.md
+++ b/plugins/dev-workflow-toolkit/README.md
@@ -72,6 +72,8 @@ The plugin registers hooks via `hooks/hooks.json` for Langfuse tracing:
 | `PostToolUse` / `PostToolUseFailure` | LLM generations (model, tokens, cost) + tool observations |
 | `SubagentStop` | Parent agent span with nested observations |
 | `SessionEnd` | Summary span with totals; cleans up state |
+| `PostToolUse` (`Edit\|Write`) | Auto-formats the touched file using the detected project toolchain (ruff/black, prettier, gofmt, rustfmt) |
+| `PreToolUse` (`Bash`) | When the command contains `git commit`, lints staged files; exits 2 to block on failure |
 
 **Setup:** Set `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`, and `LANGFUSE_SOURCE_PROJECT` env vars. The hook bootstraps its own venv at `~/.cache/langfuse-hook/venv/` on first run.
 
@@ -126,7 +128,7 @@ cd plugins/dev-workflow-toolkit
 ./tests/run-all.sh
 ```
 
-**350 tests**[^stat-test-count] across 14 modules[^stat-suite-count]:
+**368 tests**[^stat-test-count] across 15 modules[^stat-suite-count]:
 - Structure — frontmatter validation, SPEC.md checks, project-init templates, setup-rag config, cross-plugin validation
 - Integration — skill loading, dependency resolution, trigger patterns, reference files
 - Quality gate — smoke tests, negative fixtures, doc-stats validation

--- a/plugins/dev-workflow-toolkit/hooks/hooks.json
+++ b/plugins/dev-workflow-toolkit/hooks/hooks.json
@@ -65,6 +65,15 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/context-gate-hook.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-commit-linter.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -74,6 +83,15 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/langfuse-trace.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/post-edit-formatter.sh"
           }
         ]
       }

--- a/plugins/dev-workflow-toolkit/hooks/post-edit-formatter.sh
+++ b/plugins/dev-workflow-toolkit/hooks/post-edit-formatter.sh
@@ -14,12 +14,10 @@ FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev
 # Walk up from the file's directory to find the nearest project marker.
 DIR=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && pwd -P) || exit 0
 MARKER=""
-PROJECT_ROOT=""
 while [ "$DIR" != "/" ] && [ -n "$DIR" ]; do
     for M in pyproject.toml package.json go.mod Cargo.toml rustfmt.toml; do
         if [ -f "$DIR/$M" ]; then
             MARKER="$M"
-            PROJECT_ROOT="$DIR"
             break 2
         fi
     done

--- a/plugins/dev-workflow-toolkit/hooks/post-edit-formatter.sh
+++ b/plugins/dev-workflow-toolkit/hooks/post-edit-formatter.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Hook: Auto-format the file touched by Edit/Write.
+# Silent on success, on no-toolchain-detected, and on missing formatter binary.
+# Never blocks — formatter failures surface via the tool's stderr but return 0.
+
+set -uo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+[ -z "$FILE_PATH" ] && exit 0
+[ ! -f "$FILE_PATH" ] && exit 0
+
+# Walk up from the file's directory to find the nearest project marker.
+DIR=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && pwd -P) || exit 0
+MARKER=""
+PROJECT_ROOT=""
+while [ "$DIR" != "/" ] && [ -n "$DIR" ]; do
+    for M in pyproject.toml package.json go.mod Cargo.toml rustfmt.toml; do
+        if [ -f "$DIR/$M" ]; then
+            MARKER="$M"
+            PROJECT_ROOT="$DIR"
+            break 2
+        fi
+    done
+    DIR=$(dirname "$DIR")
+done
+
+[ -z "$MARKER" ] && exit 0
+
+# Dispatch to formatter based on marker + file extension.
+case "$MARKER" in
+    pyproject.toml)
+        if [[ "$FILE_PATH" == *.py ]]; then
+            if command -v ruff >/dev/null 2>&1; then
+                ruff format "$FILE_PATH" >/dev/null 2>&1 || true
+            elif command -v black >/dev/null 2>&1; then
+                black --quiet "$FILE_PATH" 2>/dev/null || true
+            fi
+        fi
+        ;;
+    package.json)
+        if [[ "$FILE_PATH" =~ \.(js|jsx|ts|tsx|json|css|scss|html|md|yml|yaml)$ ]]; then
+            if command -v prettier >/dev/null 2>&1; then
+                prettier --write "$FILE_PATH" >/dev/null 2>&1 || true
+            fi
+        fi
+        ;;
+    go.mod)
+        if [[ "$FILE_PATH" == *.go ]]; then
+            if command -v gofmt >/dev/null 2>&1; then
+                gofmt -w "$FILE_PATH" 2>/dev/null || true
+            fi
+        fi
+        ;;
+    Cargo.toml|rustfmt.toml)
+        if [[ "$FILE_PATH" == *.rs ]]; then
+            if command -v rustfmt >/dev/null 2>&1; then
+                rustfmt "$FILE_PATH" 2>/dev/null || true
+            fi
+        fi
+        ;;
+esac
+
+exit 0

--- a/plugins/dev-workflow-toolkit/hooks/pre-commit-linter.sh
+++ b/plugins/dev-workflow-toolkit/hooks/pre-commit-linter.sh
@@ -26,12 +26,12 @@ STDERR_BUF=""
 PY_FILES=$(printf '%s\n' "$STAGED" | grep -E '\.py$' || true)
 if [ -n "$PY_FILES" ] && [ -f "$REPO_ROOT/pyproject.toml" ]; then
     if command -v ruff >/dev/null 2>&1; then
-        if ! OUT=$(printf '%s\n' "$PY_FILES" | (cd "$REPO_ROOT" && xargs ruff check 2>&1)); then
+        if ! OUT=$(printf '%s\n' "$PY_FILES" | (cd "$REPO_ROOT" && xargs -d '\n' ruff check 2>&1)); then
             FAILED=1
             STDERR_BUF="${STDERR_BUF}${OUT}"$'\n'
         fi
     elif command -v flake8 >/dev/null 2>&1; then
-        if ! OUT=$(printf '%s\n' "$PY_FILES" | (cd "$REPO_ROOT" && xargs flake8 2>&1)); then
+        if ! OUT=$(printf '%s\n' "$PY_FILES" | (cd "$REPO_ROOT" && xargs -d '\n' flake8 2>&1)); then
             FAILED=1
             STDERR_BUF="${STDERR_BUF}${OUT}"$'\n'
         fi
@@ -45,7 +45,7 @@ if [ -n "$JS_FILES" ] && [ -f "$REPO_ROOT/package.json" ]; then
        [ -f "$REPO_ROOT/.eslintrc.yaml" ] || [ -f "$REPO_ROOT/.eslintrc.yml" ] || \
        [ -f "$REPO_ROOT/eslint.config.js" ] || [ -f "$REPO_ROOT/eslint.config.mjs" ]; then
         if command -v eslint >/dev/null 2>&1; then
-            if ! OUT=$(printf '%s\n' "$JS_FILES" | (cd "$REPO_ROOT" && xargs eslint 2>&1)); then
+            if ! OUT=$(printf '%s\n' "$JS_FILES" | (cd "$REPO_ROOT" && xargs -d '\n' eslint 2>&1)); then
                 FAILED=1
                 STDERR_BUF="${STDERR_BUF}${OUT}"$'\n'
             fi
@@ -62,7 +62,7 @@ if [ -n "$GO_FILES" ] && [ -f "$REPO_ROOT/go.mod" ]; then
             STDERR_BUF="${STDERR_BUF}${OUT}"$'\n'
         fi
     elif command -v gofmt >/dev/null 2>&1; then
-        OUT=$(printf '%s\n' "$GO_FILES" | (cd "$REPO_ROOT" && xargs gofmt -l 2>&1))
+        OUT=$(printf '%s\n' "$GO_FILES" | (cd "$REPO_ROOT" && xargs -d '\n' gofmt -l 2>&1))
         if [ -n "$OUT" ]; then
             FAILED=1
             STDERR_BUF="${STDERR_BUF}gofmt: files need formatting:"$'\n'"${OUT}"$'\n'

--- a/plugins/dev-workflow-toolkit/hooks/pre-commit-linter.sh
+++ b/plugins/dev-workflow-toolkit/hooks/pre-commit-linter.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Hook: PreToolUse on Bash. Block `git commit` if staged files fail project lint.
+# Exit 0 to allow, exit 2 to block (Claude Code PreToolUse protocol).
+
+set -uo pipefail
+
+INPUT=$(cat)
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Word-boundary match for 'git commit'. Matches `git commit`, `git commit -m foo`,
+# but NOT `gitcommit`, `echo "git-commit"`, or `notgit commit`.
+if ! printf '%s' "$CMD" | grep -qE '(^|[^[:alnum:]_-])git[[:space:]]+commit([^[:alnum:]_-]|$)'; then
+    exit 0
+fi
+
+git rev-parse --show-toplevel >/dev/null 2>&1 || exit 0
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
+[ -z "$STAGED" ] && exit 0
+
+FAILED=0
+STDERR_BUF=""
+
+# Python: ruff (preferred) or flake8.
+PY_FILES=$(printf '%s\n' "$STAGED" | grep -E '\.py$' || true)
+if [ -n "$PY_FILES" ] && [ -f "$REPO_ROOT/pyproject.toml" ]; then
+    if command -v ruff >/dev/null 2>&1; then
+        if ! OUT=$(printf '%s\n' "$PY_FILES" | (cd "$REPO_ROOT" && xargs ruff check 2>&1)); then
+            FAILED=1
+            STDERR_BUF="${STDERR_BUF}${OUT}"$'\n'
+        fi
+    elif command -v flake8 >/dev/null 2>&1; then
+        if ! OUT=$(printf '%s\n' "$PY_FILES" | (cd "$REPO_ROOT" && xargs flake8 2>&1)); then
+            FAILED=1
+            STDERR_BUF="${STDERR_BUF}${OUT}"$'\n'
+        fi
+    fi
+fi
+
+# JS/TS: eslint (requires package.json AND an eslint config).
+JS_FILES=$(printf '%s\n' "$STAGED" | grep -E '\.(js|jsx|ts|tsx|mjs|cjs)$' || true)
+if [ -n "$JS_FILES" ] && [ -f "$REPO_ROOT/package.json" ]; then
+    if [ -f "$REPO_ROOT/.eslintrc.js" ] || [ -f "$REPO_ROOT/.eslintrc.json" ] || \
+       [ -f "$REPO_ROOT/.eslintrc.yaml" ] || [ -f "$REPO_ROOT/.eslintrc.yml" ] || \
+       [ -f "$REPO_ROOT/eslint.config.js" ] || [ -f "$REPO_ROOT/eslint.config.mjs" ]; then
+        if command -v eslint >/dev/null 2>&1; then
+            if ! OUT=$(printf '%s\n' "$JS_FILES" | (cd "$REPO_ROOT" && xargs eslint 2>&1)); then
+                FAILED=1
+                STDERR_BUF="${STDERR_BUF}${OUT}"$'\n'
+            fi
+        fi
+    fi
+fi
+
+# Go: golangci-lint (preferred) or gofmt -l (any output = fail).
+GO_FILES=$(printf '%s\n' "$STAGED" | grep -E '\.go$' || true)
+if [ -n "$GO_FILES" ] && [ -f "$REPO_ROOT/go.mod" ]; then
+    if command -v golangci-lint >/dev/null 2>&1; then
+        if ! OUT=$(cd "$REPO_ROOT" && golangci-lint run 2>&1); then
+            FAILED=1
+            STDERR_BUF="${STDERR_BUF}${OUT}"$'\n'
+        fi
+    elif command -v gofmt >/dev/null 2>&1; then
+        OUT=$(printf '%s\n' "$GO_FILES" | (cd "$REPO_ROOT" && xargs gofmt -l 2>&1))
+        if [ -n "$OUT" ]; then
+            FAILED=1
+            STDERR_BUF="${STDERR_BUF}gofmt: files need formatting:"$'\n'"${OUT}"$'\n'
+        fi
+    fi
+fi
+
+# Rust: cargo clippy (project-wide; clippy doesn't reliably accept file paths).
+RS_FILES=$(printf '%s\n' "$STAGED" | grep -E '\.rs$' || true)
+if [ -n "$RS_FILES" ] && [ -f "$REPO_ROOT/Cargo.toml" ]; then
+    if command -v cargo >/dev/null 2>&1; then
+        if ! OUT=$(cd "$REPO_ROOT" && cargo clippy --quiet 2>&1); then
+            FAILED=1
+            STDERR_BUF="${STDERR_BUF}${OUT}"$'\n'
+        fi
+    fi
+fi
+
+if [ "$FAILED" -eq 1 ]; then
+    printf 'Pre-commit lint failed:\n%s' "$STDERR_BUF" >&2
+    exit 2
+fi
+
+exit 0

--- a/plugins/dev-workflow-toolkit/skills/SPEC.md
+++ b/plugins/dev-workflow-toolkit/skills/SPEC.md
@@ -82,7 +82,8 @@ Skills compose into a development workflow graph. The primary flow is:
 | INV-19 | `finishing-a-development-branch` Step 5c detects worktree context and omits `--delete-branch` when inside a worktree, cleaning up the remote branch via `gh api` instead | structural | `gh pr merge --delete-branch` fails from worktrees because its post-merge `git checkout main` collides with the main worktree |
 | INV-20 | `finishing-a-development-branch` Step 5c checks for fast-forward topology (`git merge-base --is-ancestor main HEAD`) before squashing and warns the user | reasoning-required | GitHub silently fast-forwards rebased branches even when `--squash` is requested, defeating the squash-merge intent |
 | INV-21 | Implementer subagents dispatched by `subagent-driven-development` run tests, lint, and format before reporting completion, and paste fresh command output as evidence | reasoning-required | Shifts quality enforcement left — reviewers catch meaningful issues instead of basic compilation/lint failures; prevents wasted review cycles |
-| INV-22 | Post-edit formatter hook (`post-edit-formatter.sh`) runs synchronously after `Edit`/`Write` and reformats the touched file using the detected project toolchain; pre-commit linter hook (`pre-commit-linter.sh`) blocks `git commit` commands (exit 2) when staged files fail project lint | structural | Shifts code hygiene from agent attention to mechanical enforcement; prevents unformatted or unlinted code from being committed |
+| INV-22 | Post-edit formatter hook (`post-edit-formatter.sh`) runs synchronously after `Edit`/`Write` and reformats the touched file using the detected project toolchain (ruff/black, prettier, gofmt, rustfmt); silent when no toolchain is detected | structural | Removes "did I format this?" from the agent's attention; prevents unformatted code from being committed |
+| INV-23 | Pre-commit linter hook (`pre-commit-linter.sh`) blocks `git commit` commands (exit 2) when staged files fail the project linter (ruff, eslint, golangci-lint, cargo clippy); silent when no toolchain or no staged files | structural | Moves lint enforcement from the agent's attention to a mechanical gate; prevents unlinted code from being committed |
 
 **Enforcement classification:**
 - **structural** — enforced by test suite, gitignore structure, or directory convention; pattern-matchable
@@ -115,7 +116,7 @@ lifecycle points (plan summaries, progress updates, review findings).
 | FAIL-15 | `gh pr merge --delete-branch` reports "main is already used by worktree" | Running `gh pr merge --delete-branch` from a worktree triggers a conflicting `git checkout main` | Step 5c detects worktree context, drops `--delete-branch`, and deletes the remote branch via `gh api` (#162) |
 | FAIL-16 | Squash merge preserved all individual commits on main | GitHub fast-forwards rebased branches even when `--squash` is requested | Step 5c checks `git merge-base --is-ancestor` before squashing and warns when fast-forward is imminent (#156) |
 | FAIL-17 | Implementer reports completion without running tests/lint/format | Pre-Report Gate missing from `implementer-prompt.md` or subagent ignored it | Re-dispatch implementer with explicit reference to the Pre-Report Gate in `implementer-prompt.md`; reject the completion claim until fresh test/lint/format output is pasted |
-| FAIL-18 | `git commit` blocked by pre-commit linter hook | Staged files fail the project linter (ruff, eslint, golangci-lint, cargo clippy) | Read the stderr output from the hook; fix the reported issues; re-stage; retry commit |
+| FAIL-18 | `git commit` blocked by pre-commit linter hook (INV-23) | Staged files fail the project linter (ruff, eslint, golangci-lint, cargo clippy) | Read the stderr output from the hook; fix the reported issues; re-stage; retry. Do NOT bypass with `--no-verify` — that skips the gate and defeats its purpose |
 
 ## Decision Framework
 
@@ -151,7 +152,8 @@ INV-18: structural — enforced by `test_inv18_no_fail_on_error_flag` (scans SKI
 INV-19: structural — enforced by `test_inv19_worktree_aware_merge` (scans Step 5c for detection + API cleanup).
 INV-20: reasoning-required — verified by `test_inv20_fast_forward_detection` (scans Step 5c for merge-base check) and during code review.
 INV-21: reasoning-required — verified by presence of the `## Pre-Report Gate` section in `subagent-driven-development/implementer-prompt.md` during code review; candidate for a string-presence structural test in a follow-up.
-INV-22: structural — enforced by `test_formatter_linter_hooks.py` (script presence, exit codes, detection dispatch).
+INV-22: structural — enforced by `test_formatter_linter_hooks.py::TestPostEditFormatter` (script presence, formatter dispatch, silent-on-miss).
+INV-23: structural — enforced by `test_formatter_linter_hooks.py::TestPreCommitLinter` (script presence, exit-2-on-failure, word-boundary matching, silent-on-no-toolchain).
 
 Skills are additionally validated via subagent pressure testing — see `/skill-creator`.
 

--- a/plugins/dev-workflow-toolkit/skills/SPEC.md
+++ b/plugins/dev-workflow-toolkit/skills/SPEC.md
@@ -82,6 +82,7 @@ Skills compose into a development workflow graph. The primary flow is:
 | INV-19 | `finishing-a-development-branch` Step 5c detects worktree context and omits `--delete-branch` when inside a worktree, cleaning up the remote branch via `gh api` instead | structural | `gh pr merge --delete-branch` fails from worktrees because its post-merge `git checkout main` collides with the main worktree |
 | INV-20 | `finishing-a-development-branch` Step 5c checks for fast-forward topology (`git merge-base --is-ancestor main HEAD`) before squashing and warns the user | reasoning-required | GitHub silently fast-forwards rebased branches even when `--squash` is requested, defeating the squash-merge intent |
 | INV-21 | Implementer subagents dispatched by `subagent-driven-development` run tests, lint, and format before reporting completion, and paste fresh command output as evidence | reasoning-required | Shifts quality enforcement left — reviewers catch meaningful issues instead of basic compilation/lint failures; prevents wasted review cycles |
+| INV-22 | Post-edit formatter hook (`post-edit-formatter.sh`) runs synchronously after `Edit`/`Write` and reformats the touched file using the detected project toolchain; pre-commit linter hook (`pre-commit-linter.sh`) blocks `git commit` commands (exit 2) when staged files fail project lint | structural | Shifts code hygiene from agent attention to mechanical enforcement; prevents unformatted or unlinted code from being committed |
 
 **Enforcement classification:**
 - **structural** — enforced by test suite, gitignore structure, or directory convention; pattern-matchable
@@ -114,6 +115,7 @@ lifecycle points (plan summaries, progress updates, review findings).
 | FAIL-15 | `gh pr merge --delete-branch` reports "main is already used by worktree" | Running `gh pr merge --delete-branch` from a worktree triggers a conflicting `git checkout main` | Step 5c detects worktree context, drops `--delete-branch`, and deletes the remote branch via `gh api` (#162) |
 | FAIL-16 | Squash merge preserved all individual commits on main | GitHub fast-forwards rebased branches even when `--squash` is requested | Step 5c checks `git merge-base --is-ancestor` before squashing and warns when fast-forward is imminent (#156) |
 | FAIL-17 | Implementer reports completion without running tests/lint/format | Pre-Report Gate missing from `implementer-prompt.md` or subagent ignored it | Re-dispatch implementer with explicit reference to the Pre-Report Gate in `implementer-prompt.md`; reject the completion claim until fresh test/lint/format output is pasted |
+| FAIL-18 | `git commit` blocked by pre-commit linter hook | Staged files fail the project linter (ruff, eslint, golangci-lint, cargo clippy) | Read the stderr output from the hook; fix the reported issues; re-stage; retry commit |
 
 ## Decision Framework
 
@@ -149,6 +151,7 @@ INV-18: structural — enforced by `test_inv18_no_fail_on_error_flag` (scans SKI
 INV-19: structural — enforced by `test_inv19_worktree_aware_merge` (scans Step 5c for detection + API cleanup).
 INV-20: reasoning-required — verified by `test_inv20_fast_forward_detection` (scans Step 5c for merge-base check) and during code review.
 INV-21: reasoning-required — verified by presence of the `## Pre-Report Gate` section in `subagent-driven-development/implementer-prompt.md` during code review; candidate for a string-presence structural test in a follow-up.
+INV-22: structural — enforced by `test_formatter_linter_hooks.py` (script presence, exit codes, detection dispatch).
 
 Skills are additionally validated via subagent pressure testing — see `/skill-creator`.
 

--- a/plugins/dev-workflow-toolkit/tests/test_formatter_linter_hooks.py
+++ b/plugins/dev-workflow-toolkit/tests/test_formatter_linter_hooks.py
@@ -6,6 +6,9 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import shutil
+
+_HAS_RUFF = shutil.which("ruff") is not None
 
 _HOOK_ENV_BASE = {"PATH": "/usr/bin:/bin:/usr/local/bin"}
 
@@ -91,6 +94,7 @@ class TestPostEditFormatter:
         )
         assert result.returncode == 0
 
+    @pytest.mark.skipif(not _HAS_RUFF, reason="ruff not available")
     def test_formats_python_file_with_ruff(
         self, hooks_dir: Path, tmp_path: Path
     ):
@@ -98,10 +102,6 @@ class TestPostEditFormatter:
         (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
         unformatted = tmp_path / "src.py"
         unformatted.write_text("x  =  1\n")
-        if subprocess.run(
-            ["which", "ruff"], capture_output=True
-        ).returncode != 0:
-            pytest.skip("ruff not available in test env")
         result = _run_hook(
             hooks_dir / "post-edit-formatter.sh",
             tmp_path,
@@ -127,6 +127,7 @@ class TestPostEditFormatter:
         assert result.returncode == 0
         assert f.read_text() == original
 
+    @pytest.mark.skipif(not _HAS_RUFF, reason="ruff not available")
     def test_detects_project_marker_walking_up(
         self, hooks_dir: Path, tmp_path: Path
     ):
@@ -136,10 +137,6 @@ class TestPostEditFormatter:
         subdir.mkdir(parents=True)
         f = subdir / "deep.py"
         f.write_text("x=1\n")
-        if subprocess.run(
-            ["which", "ruff"], capture_output=True
-        ).returncode != 0:
-            pytest.skip("ruff not available in test env")
         result = _run_hook(
             hooks_dir / "post-edit-formatter.sh",
             tmp_path,

--- a/plugins/dev-workflow-toolkit/tests/test_formatter_linter_hooks.py
+++ b/plugins/dev-workflow-toolkit/tests/test_formatter_linter_hooks.py
@@ -1,0 +1,150 @@
+"""Tests for post-edit-formatter and pre-commit-linter hooks."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_HOOK_ENV_BASE = {"PATH": "/usr/bin:/bin:/usr/local/bin"}
+
+
+@pytest.fixture
+def hooks_dir(plugin_root: Path) -> Path:
+    return plugin_root / "hooks"
+
+
+def _run_hook(
+    script: Path,
+    cwd: Path,
+    stdin_json: dict,
+    extra_env: dict | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a hook script with JSON stdin; return the result."""
+    env = {**_HOOK_ENV_BASE, "HOME": str(cwd)}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [str(script)],
+        cwd=cwd,
+        input=json.dumps(stdin_json),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _init_git_repo(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path, capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path, capture_output=True, check=True,
+    )
+
+
+class TestPostEditFormatter:
+    """Tests for post-edit-formatter.sh."""
+
+    def test_script_exists_and_executable(self, hooks_dir: Path):
+        script = hooks_dir / "post-edit-formatter.sh"
+        assert script.exists(), f"Script not found: {script}"
+        assert script.stat().st_mode & 0o111, "Script must be executable"
+
+    def test_silent_when_no_file_path_in_input(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """Hook exits 0 silently if tool_input has no file_path."""
+        result = _run_hook(
+            hooks_dir / "post-edit-formatter.sh",
+            tmp_path,
+            {"tool_input": {}},
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_silent_when_file_does_not_exist(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """Hook exits 0 silently if file_path does not exist on disk."""
+        result = _run_hook(
+            hooks_dir / "post-edit-formatter.sh",
+            tmp_path,
+            {"tool_input": {"file_path": str(tmp_path / "missing.py")}},
+        )
+        assert result.returncode == 0
+
+    def test_silent_when_no_project_marker(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """Hook exits 0 silently if no project marker is found walking up."""
+        f = tmp_path / "orphan.py"
+        f.write_text("x=1\n")
+        result = _run_hook(
+            hooks_dir / "post-edit-formatter.sh",
+            tmp_path,
+            {"tool_input": {"file_path": str(f)}},
+        )
+        assert result.returncode == 0
+
+    def test_formats_python_file_with_ruff(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """pyproject.toml present + ruff on PATH → file gets formatted."""
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+        unformatted = tmp_path / "src.py"
+        unformatted.write_text("x  =  1\n")
+        if subprocess.run(
+            ["which", "ruff"], capture_output=True
+        ).returncode != 0:
+            pytest.skip("ruff not available in test env")
+        result = _run_hook(
+            hooks_dir / "post-edit-formatter.sh",
+            tmp_path,
+            {"tool_input": {"file_path": str(unformatted)}},
+            extra_env={"PATH": os.environ["PATH"]},
+        )
+        assert result.returncode == 0
+        assert unformatted.read_text() == "x = 1\n"
+
+    def test_silent_when_formatter_binary_absent(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """pyproject.toml present but ruff/black not on PATH → no-op, exit 0."""
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+        f = tmp_path / "src.py"
+        original = "x  =  1\n"
+        f.write_text(original)
+        result = _run_hook(
+            hooks_dir / "post-edit-formatter.sh",
+            tmp_path,
+            {"tool_input": {"file_path": str(f)}},
+        )
+        assert result.returncode == 0
+        assert f.read_text() == original
+
+    def test_detects_project_marker_walking_up(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """File in nested subdir → walks up to find pyproject.toml."""
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+        subdir = tmp_path / "a" / "b" / "c"
+        subdir.mkdir(parents=True)
+        f = subdir / "deep.py"
+        f.write_text("x=1\n")
+        if subprocess.run(
+            ["which", "ruff"], capture_output=True
+        ).returncode != 0:
+            pytest.skip("ruff not available in test env")
+        result = _run_hook(
+            hooks_dir / "post-edit-formatter.sh",
+            tmp_path,
+            {"tool_input": {"file_path": str(f)}},
+            extra_env={"PATH": os.environ["PATH"]},
+        )
+        assert result.returncode == 0
+        assert f.read_text() == "x = 1\n"

--- a/plugins/dev-workflow-toolkit/tests/test_formatter_linter_hooks.py
+++ b/plugins/dev-workflow-toolkit/tests/test_formatter_linter_hooks.py
@@ -145,3 +145,114 @@ class TestPostEditFormatter:
         )
         assert result.returncode == 0
         assert f.read_text() == "x = 1\n"
+
+
+class TestPreCommitLinter:
+    """Tests for pre-commit-linter.sh."""
+
+    def test_script_exists_and_executable(self, hooks_dir: Path):
+        script = hooks_dir / "pre-commit-linter.sh"
+        assert script.exists(), f"Script not found: {script}"
+        assert script.stat().st_mode & 0o111, "Script must be executable"
+
+    def test_silent_on_non_commit_bash(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """Bash commands that are not 'git commit' → exit 0, no stderr."""
+        _init_git_repo(tmp_path)
+        result = _run_hook(
+            hooks_dir / "pre-commit-linter.sh",
+            tmp_path,
+            {"tool_input": {"command": "ls -la"}},
+        )
+        assert result.returncode == 0
+        assert result.stderr == ""
+
+    def test_silent_when_no_staged_files(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """git commit with no staged files → exit 0."""
+        _init_git_repo(tmp_path)
+        result = _run_hook(
+            hooks_dir / "pre-commit-linter.sh",
+            tmp_path,
+            {"tool_input": {"command": "git commit -m 'empty'"}},
+        )
+        assert result.returncode == 0
+
+    def test_silent_when_no_toolchain_detected(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """git commit in a repo with no lang marker → exit 0."""
+        _init_git_repo(tmp_path)
+        f = tmp_path / "README.md"
+        f.write_text("hi\n")
+        subprocess.run(
+            ["git", "add", "README.md"],
+            cwd=tmp_path, capture_output=True, check=True,
+        )
+        result = _run_hook(
+            hooks_dir / "pre-commit-linter.sh",
+            tmp_path,
+            {"tool_input": {"command": "git commit -m 'add readme'"}},
+        )
+        assert result.returncode == 0
+
+    @pytest.mark.skipif(not _HAS_RUFF, reason="ruff not available")
+    def test_allows_clean_python_commit(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """Clean staged Python file → exit 0."""
+        _init_git_repo(tmp_path)
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+        f = tmp_path / "clean.py"
+        f.write_text("x = 1\n")
+        subprocess.run(
+            ["git", "add", "clean.py", "pyproject.toml"],
+            cwd=tmp_path, capture_output=True, check=True,
+        )
+        result = _run_hook(
+            hooks_dir / "pre-commit-linter.sh",
+            tmp_path,
+            {"tool_input": {"command": "git commit -m 'ok'"}},
+            extra_env={"PATH": os.environ["PATH"]},
+        )
+        assert result.returncode == 0
+
+    @pytest.mark.skipif(not _HAS_RUFF, reason="ruff not available")
+    def test_blocks_dirty_python_commit(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """Staged Python file with lint error → exit 2, stderr mentions file."""
+        _init_git_repo(tmp_path)
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname='x'\n"
+            "[tool.ruff.lint]\nselect=['F']\n"
+        )
+        # F401 = unused import
+        f = tmp_path / "dirty.py"
+        f.write_text("import os\n")
+        subprocess.run(
+            ["git", "add", "dirty.py", "pyproject.toml"],
+            cwd=tmp_path, capture_output=True, check=True,
+        )
+        result = _run_hook(
+            hooks_dir / "pre-commit-linter.sh",
+            tmp_path,
+            {"tool_input": {"command": "git commit -m 'bad'"}},
+            extra_env={"PATH": os.environ["PATH"]},
+        )
+        assert result.returncode == 2
+        assert "dirty.py" in result.stderr
+
+    def test_word_boundary_on_git_commit(
+        self, hooks_dir: Path, tmp_path: Path
+    ):
+        """Commands containing 'gitcommit' (no space) should NOT trigger."""
+        _init_git_repo(tmp_path)
+        result = _run_hook(
+            hooks_dir / "pre-commit-linter.sh",
+            tmp_path,
+            {"tool_input": {"command": "echo gitcommit"}},
+        )
+        assert result.returncode == 0

--- a/plugins/dev-workflow-toolkit/tests/test_formatter_linter_hooks.py
+++ b/plugins/dev-workflow-toolkit/tests/test_formatter_linter_hooks.py
@@ -245,14 +245,23 @@ class TestPreCommitLinter:
         assert result.returncode == 2
         assert "dirty.py" in result.stderr
 
+    @pytest.mark.parametrize("command", [
+        "echo gitcommit",
+        "echo gitcommits",
+        "echo git-commit",
+        "echo mygit commit",
+        "echo 'fake git_commit'",
+    ])
     def test_word_boundary_on_git_commit(
-        self, hooks_dir: Path, tmp_path: Path
+        self, hooks_dir: Path, tmp_path: Path, command: str
     ):
-        """Commands containing 'gitcommit' (no space) should NOT trigger."""
+        """Commands that merely contain commit-like substrings must NOT trigger lint."""
         _init_git_repo(tmp_path)
         result = _run_hook(
             hooks_dir / "pre-commit-linter.sh",
             tmp_path,
-            {"tool_input": {"command": "echo gitcommit"}},
+            {"tool_input": {"command": command}},
         )
-        assert result.returncode == 0
+        assert result.returncode == 0, (
+            f"Hook triggered on non-commit command: {command!r}"
+        )


### PR DESCRIPTION
## Summary

Adds two hooks to `dev-workflow-toolkit` that mechanically enforce code hygiene, removing the attention burden from agents:

- **`hooks/post-edit-formatter.sh`** — `PostToolUse` on `Edit|Write`. Detects the project's toolchain (pyproject.toml / package.json / go.mod / Cargo.toml) by walking up from the edited file, and formats with ruff/black, prettier, gofmt, or rustfmt. Silent when no toolchain is detected; never blocks.
- **`hooks/pre-commit-linter.sh`** — `PreToolUse` on `Bash`. When the command contains `git commit` (word-boundary match), runs the project linter (ruff/flake8, eslint, golangci-lint/gofmt, cargo clippy) on staged files only. Exits 2 to block the commit on any failure; silent when no toolchain or no staged files.

Both hooks auto-register via `hooks/hooks.json` when the plugin is installed. New invariants: **INV-22** (formatter) + **INV-23** (linter, structural); new failure mode: **FAIL-18** (commit blocked by lint — forbids `--no-verify` bypass).

## Test Plan

- [x] `./tests/run-all.sh` passes (366 passed, 2 capability-guard skipped, 0 failed)
- [x] Quality gate passes (87/87 including INV-1..INV-23 and FAIL-1..FAIL-18 sequential)
- [x] `test_formatter_linter_hooks.py`: 18 tests across `TestPostEditFormatter` (7) + `TestPreCommitLinter` (11 — 7 methods + parametrized word-boundary coverage)
- [x] Both hook scripts executable; `bash -n` clean
- [x] `hooks.json` valid JSON with both entries; existing langfuse + context-gate hooks byte-identical
- [x] README, SPEC, CHANGELOG updated per design doc

<details><summary>Design Doc</summary>

See \`.claude/plans/2026-04-20-formatter-linter-hooks-design.md\` (local). Key decisions: Python + JS/TS + Go + Rust toolchains in v1; silent on miss; staged-files-only lint.

</details>

<details><summary>Implementation Plan</summary>

See \`.claude/plans/2026-04-20-formatter-linter-hooks-plan.md\` (local). Three tasks: formatter hook, linter hook, wire-up/docs. Each task ran through implementer + spec review + code-quality review with fix cycles.

</details>

**Review documentation:** Spec + quality reviews posted to issue #146 for each task ([Task 1](https://github.com/stvhay/my-claude-plugins/issues/146#issuecomment-4277220333), [Task 2](https://github.com/stvhay/my-claude-plugins/issues/146#issuecomment-4277237134), [Task 3](https://github.com/stvhay/my-claude-plugins/issues/146#issuecomment-4277263395)).

Closes #146