### PR TITLE
Incorporate draft web-ui-theming plugin as web-ui-theming-tampermonkey

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,6 +61,12 @@
       "description": "MCP server: per-project SSH host registry; run/upload/download tools shell out to system ssh and never edit ~/.ssh/config",
       "license": "Apache-2.0",
       "source": "./plugins/ssh-mcp"
+    },
+    {
+      "name": "web-ui-theming-tampermonkey",
+      "description": "Layer themes onto existing HTML applications via userscripts (Tampermonkey/Greasemonkey/Stylus). Vendor real CSS, drive iteration with screenshot + Claude Vision, and persist finalized styles by name for reuse on future sites.",
+      "license": "Apache-2.0",
+      "source": "./plugins/web-ui-theming-tampermonkey"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Personal Claude Code plugin marketplace.
 | [redteam](plugins/redteam/) | Adversarial analysis with parallel agent deployment: stress-test ideas and produce content through competition |
 | [dev-workflow-toolkit](plugins/dev-workflow-toolkit/) | Development workflow skills: brainstorming, planning, execution, debugging, testing, code review, project scaffolding, retrospective, and automated quality gates |
 | [ssh-mcp](plugins/ssh-mcp/) | MCP server: per-project SSH host registry; `run`/`upload`/`download` tools that shell out to system `ssh` and never edit `~/.ssh/config` |
+| [web-ui-theming-tampermonkey](plugins/web-ui-theming-tampermonkey/) | Layer themes onto existing HTML applications via userscripts (Tampermonkey/Greasemonkey/Stylus). Vendor real CSS, drive iteration with screenshot + Claude Vision, and persist finalized styles by name for reuse on future sites. |
 
 ## Documentation
 

--- a/plugins/web-ui-theming-tampermonkey/.claude-plugin/plugin.json
+++ b/plugins/web-ui-theming-tampermonkey/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "web-ui-theming-tampermonkey",
+  "description": "Layer themes onto existing HTML applications via userscripts (Tampermonkey/Greasemonkey/Stylus). Vendor real CSS, drive iteration with screenshot + Claude Vision, and persist finalized styles by name for reuse on future sites.",
+  "version": "0.1.0",
+  "author": {
+    "name": "stvhay"
+  },
+  "license": "Apache-2.0"
+}

--- a/plugins/web-ui-theming-tampermonkey/CHANGELOG.md
+++ b/plugins/web-ui-theming-tampermonkey/CHANGELOG.md
@@ -12,6 +12,7 @@ bcd213ff on 2026-04-26).
   `vision-verification.md`, `existing-themes.md`.
 - Reusable Playwright screenshot rig parameterized for any site.
 - First named style: `themes/luci-dark-material.md`.
-- Plugin renamed from `web-ui-theming` to `web-ui-theming-tampermonkey` on incorporation, reserving the `web-ui-theming-*` namespace for future delivery-target siblings (e.g. Stylus-only, browser-extension).
+- Plugin renamed from `web-ui-theming` to `web-ui-theming-tampermonkey` on incorporation.
+- Reserves the `web-ui-theming-*` namespace for future delivery-target siblings (e.g. Stylus-only, browser-extension).
 - Added plugin-level `DESIGN.md` (load-bearing intent extracted from the now-removed `TURNOVER.md`).
 - Added `skills/SPEC.md`.

--- a/plugins/web-ui-theming-tampermonkey/CHANGELOG.md
+++ b/plugins/web-ui-theming-tampermonkey/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+<!-- bump: patch -->
+
+### Changed
+
+- Plugin renamed from `web-ui-theming` to `web-ui-theming-tampermonkey` on incorporation. Reserves the `web-ui-theming-*` namespace for future delivery-target siblings (e.g. Stylus-only, browser-extension).
+
+### Added
+
+- Plugin-level `DESIGN.md` (load-bearing design intent extracted from the now-removed `TURNOVER.md`).
+- `skills/SPEC.md`.
+
 ## 0.1.0 — 2026-04-27
 
 Initial release. Distilled from the LuCI Material Dark Mode project
@@ -12,7 +25,3 @@ bcd213ff on 2026-04-26).
   `vision-verification.md`, `existing-themes.md`.
 - Reusable Playwright screenshot rig parameterized for any site.
 - First named style: `themes/luci-dark-material.md`.
-- Plugin renamed from `web-ui-theming` to `web-ui-theming-tampermonkey` on incorporation.
-- Reserves the `web-ui-theming-*` namespace for future delivery-target siblings (e.g. Stylus-only, browser-extension).
-- Added plugin-level `DESIGN.md` (load-bearing intent extracted from the now-removed `TURNOVER.md`).
-- Added `skills/SPEC.md`.

--- a/plugins/web-ui-theming-tampermonkey/CHANGELOG.md
+++ b/plugins/web-ui-theming-tampermonkey/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.1.0 — 2026-04-27
+
+Initial release. Distilled from the LuCI Material Dark Mode project
+(`luci-material-dark-mode/`, sessions 8cc01486 / d3719986 / fa30cf91 /
+bcd213ff on 2026-04-26).
+
+- `layer-theme` skill: 6-phase workflow (intent → acquire → study → fixture
+  rig → iterate-with-vision → finalize-and-name).
+- References: `upstream-acquisition.md`, `design-principles.md`,
+  `vision-verification.md`, `existing-themes.md`.
+- Reusable Playwright screenshot rig parameterized for any site.
+- First named style: `themes/luci-dark-material.md`.
+- Plugin renamed from `web-ui-theming` to `web-ui-theming-tampermonkey` on incorporation, reserving the `web-ui-theming-*` namespace for future delivery-target siblings (e.g. Stylus-only, browser-extension).
+- Added plugin-level `DESIGN.md` (load-bearing intent extracted from the now-removed `TURNOVER.md`).
+- Added `skills/SPEC.md`.

--- a/plugins/web-ui-theming-tampermonkey/DESIGN.md
+++ b/plugins/web-ui-theming-tampermonkey/DESIGN.md
@@ -1,0 +1,29 @@
+# Design Intent — what to preserve across iterations
+
+These are the load-bearing ideas behind the `layer-theme` skill. If a future change would compromise one of these, push back hard.
+
+> In the context of theming third-party HTML apps via userscripts, facing the risk that overconfident analytical reasoning replaces visual verification, we mechanically gate every visual claim on a fresh screenshot + Claude-Vision Read, accepting one extra Read tool call per iteration in exchange for the elimination of "I see it" hallucinations.
+
+## Vision API > analytical reasoning
+
+For any visual claim — alignment, contrast, "looks good now," "I see it" — require a freshly-rendered PNG and a Read of that PNG **in the same turn**. The overconfidence trap is named, mechanically gated (Iron Laws #3 and #4), and cited from Phase 5. **Don't soften.** Analytical reasoning about what a screenshot would show is *not* a substitute for actually loading it. The cost of one extra Read is ~zero; the cost of being wrong is the user typing *"why can't you see this?"* for the third time.
+
+## Generality is a quality metric
+
+Specific selectors are debt; class families and slot patterns are equity. Every site-specific selector — page IDs, `nth-child` indexes, single-element targets — is debt. The Phase 6 generality self-check exists because the original LuCI session converged on a complex solution before refactoring back to principles. **Don't let future iterations slide back.** A theme's quality is measured by how *few* and how *general* its rules are.
+
+## Vendor real CSS, not approximations
+
+Approximated CSS produces approximated bugs. Save upstream's stylesheet under `theme-vendor/` and link to it from your fixtures. Never approximate. (Iron Law #1.)
+
+## Critique before patching
+
+The Phase 3 critique document is the gate between *"user said something looks half-baked"* and writing selectors. Don't bypass. The critique converts symptoms into principles (saturation, weight tier, slot pattern, hover progression) and groups findings under them. Fix lists fall out of the principles, not the symptoms.
+
+## Regression report = signal worth more than the bug
+
+Every user-reported regression runs the 4-branch assessment from `templates/regression-assessment.md`, propagates as durable knowledge, and grows the test rig. Patches without classification waste the signal.
+
+## The named-style catalog is the long-term value
+
+Each finalized theme leaves behind a portable spec under `themes/<name>.md`. After 5–10 themes the catalog becomes a small palette / pattern library that makes new theming work ~50% faster. The catalog is the single most durable artifact this skill produces.

--- a/plugins/web-ui-theming-tampermonkey/README.md
+++ b/plugins/web-ui-theming-tampermonkey/README.md
@@ -1,4 +1,4 @@
-# web-ui-theming
+# web-ui-theming-tampermonkey
 
 Claude Code plugin for layering themes onto existing HTML applications.
 
@@ -24,7 +24,7 @@ userscript (or plain CSS) that re-tones a site without touching its source.
 
 ## Install
 
-This plugin lives in `plugin/web-ui-theming/`. To install via the
+This plugin lives in `plugins/web-ui-theming-tampermonkey/`. To install via the
 my-claude-plugins marketplace, copy the directory into
 `marketplaces/my-claude-plugins/plugins/` and add an entry to that
 marketplace's plugin index, then `/plugin install web-ui-theming-tampermonkey@my-claude-plugins`.

--- a/plugins/web-ui-theming-tampermonkey/README.md
+++ b/plugins/web-ui-theming-tampermonkey/README.md
@@ -1,0 +1,39 @@
+# web-ui-theming
+
+Claude Code plugin for layering themes onto existing HTML applications.
+
+Single skill: **`layer-theme`**. Output: a Tampermonkey/Greasemonkey/Stylus
+userscript (or plain CSS) that re-tones a site without touching its source.
+
+## What it gives Claude
+
+- A phased workflow that **studies upstream design intent** before writing
+  selectors — so the result expresses general UX principles instead of
+  whack-a-moling individual components.
+- A **screenshot + Claude Vision** verification rig (`scripts/screenshot.py`)
+  that reuses real vendored CSS, so visual tests run against production CSS
+  without needing the live site.
+- A **named-style catalog** (`skills/layer-theme/themes/`) — once a visual
+  style is finalized for one site, it can be referenced by name when theming
+  another.
+- Reference docs covering: source acquisition (including how to ask the user
+  to grab assets when the source isn't reachable), the contrast / alignment
+  / weight / stacking-context checklist that the LuCI work surfaced as
+  load-bearing, vision-verification protocol with cache-busting, and existing
+  popular-theme sources (Stylus, userstyles.world) to reverse-engineer.
+
+## Install
+
+This plugin lives in `plugin/web-ui-theming/`. To install via the
+my-claude-plugins marketplace, copy the directory into
+`marketplaces/my-claude-plugins/plugins/` and add an entry to that
+marketplace's plugin index, then `/plugin install web-ui-theming-tampermonkey@my-claude-plugins`.
+
+## Provenance
+
+Distilled from a single day of work building `dark-mode.user.js` for OpenWrt's
+LuCI Material theme (April 2026, 4 sessions, ~4h). See `CHANGELOG.md`.
+
+## License
+
+Apache 2.0.

--- a/plugins/web-ui-theming-tampermonkey/skills/SPEC.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/SPEC.md
@@ -1,0 +1,87 @@
+# Skills Subsystem
+
+## Purpose
+
+The web-ui-theming-tampermonkey skills directory provides one skill: `layer-theme`. It encodes a phased workflow for layering themes onto existing HTML applications you don't own — dark mode, brand re-tone, density adjustments — delivered as a userscript (Tampermonkey/Greasemonkey/Stylus) or a UserStyle.
+
+The key design decision: themes are produced **archaeologically + visually** — read the upstream designer's intent from CSS variables and class names, override at the right tier, and verify with screenshots that respect the underlying UX hierarchy rather than patching individual selectors. Quality is measured by how *few* and *general* the resulting rules are.
+
+## Core Mechanism
+
+A six-phase workflow gated by nine "Iron Laws" that turn visual claims from analytical reasoning into mechanical verification: vendor the upstream CSS, study the design tokens before writing selectors, render every iteration with Playwright, and Read the resulting PNG via Claude Vision before claiming a visual outcome. The named-style catalog (`themes/`) accumulates portable theme specs for reuse on future sites.
+
+**Key files:**
+- `layer-theme/SKILL.md` — Iron Laws + 6-phase workflow (intent → acquire → study → fixture rig → iterate-with-vision → finalize-and-name)
+- `layer-theme/scripts/screenshot.py` — Playwright harness with V8 syntax pre-check, GM_addStyle polyfill, interactive states
+- `layer-theme/scripts/contrast.py` — Element-level WCAG AA contrast check via Playwright
+- `layer-theme/references/upstream-acquisition.md` — How to vendor real upstream CSS (3 modes, including how to ask the user for assets)
+- `layer-theme/references/design-principles.md` — Generality, tokens, slot patterns, stacking-context traps
+- `layer-theme/references/vision-verification.md` — Overconfidence-trap protocol, per-state checklist
+- `layer-theme/references/existing-themes.md` — userstyles.world, Greasy Fork, palette ports
+- `layer-theme/templates/userscript.user.js` — Two-tier override skeleton with slot patterns
+- `layer-theme/templates/fixture.html` — Representative fixture with declared interactive states
+- `layer-theme/templates/critique.md` — Phase 3 design-brief
+- `layer-theme/templates/theme-spec.md` — Named-style template
+- `layer-theme/templates/regression-assessment.md` — 4-branch self-improvement loop
+- `layer-theme/themes/` — Catalog of finalized named styles (`luci-dark-material.md` is the first)
+
+## Public Interface
+
+| Export | Used By | Contract |
+|---|---|---|
+| YAML frontmatter `name: layer-theme` | Claude Code skill router | Unique, lowercase, matches directory name |
+| Phase 6 finalize step | The user, on completion | Produces a named theme spec under `themes/<name>.md` |
+| `themes/<name>.md` references | Future invocations like "apply the luci-dark-material style to grafana" | Self-contained palette + pattern library, readable by future skill invocations |
+| `scripts/screenshot.py` / `scripts/contrast.py` | Skill-internal Phase 5 verification | Run from a project's working directory; expects `theme-vendor/`, `fixtures/`, and a userscript file |
+
+## Invariants
+
+| ID | Invariant | Enforcement | Why It Matters |
+|---|---|---|---|
+| INV-1 | SKILL.md has valid YAML frontmatter with `name: layer-theme` and a non-empty `description` | structural | Claude Code cannot discover skills without frontmatter |
+| INV-2 | Visual claims must be backed by a freshly-rendered screenshot AND a Claude-Vision Read of that PNG in the same turn | reasoning-required | The "overconfidence trap" — analytical reasoning about CSS rules silently misrepresents visual outcomes (Iron Laws #3 + #4) |
+| INV-3 | Vendor real upstream CSS into `theme-vendor/`; never approximate | reasoning-required | Approximated CSS produces approximated bugs (Iron Law #1) |
+| INV-4 | Phase 3 critique document exists before Phase 4 selectors are written | reasoning-required | A critique converts "this looks half-baked" into principles before tactics; bypassing produces whack-a-mole rules |
+| INV-5 | Themes prefer class families and slot patterns over `nth-child` / single-ID selectors | reasoning-required | Specific selectors are debt; generality is a quality metric (Iron Law #9) |
+
+**Enforcement classification:**
+- **structural** — enforced by test suite or directory convention
+- **reasoning-required** — needs architectural understanding; verified during code review or skill behavior
+
+## Failure Modes
+
+| ID | Symptom | Cause | Fix |
+|---|---|---|---|
+| FAIL-1 | Skill not triggered when user asks for theming work | Missing or malformed YAML frontmatter | Add `---` fenced frontmatter with `name: layer-theme` and a `description` |
+| FAIL-2 | "Looks good now" claimed without a fresh PNG read | Iron Law #4 violated; INV-2 unmet | Run `scripts/screenshot.py`, then Read the resulting PNG in the same turn before claiming a visual outcome |
+| FAIL-3 | Hover tooltip / dropdown clipped after applying `filter:` to parent | Stacking-context trap (Iron Law #7) | Prefer `color-mix()` on `background-color` over filter-based desaturation |
+| FAIL-4 | Theme passes page-level contrast but fails on individual buttons | Background mismatch (Iron Law #8) | Compare each text node's computed color to its actual rendered background, not the page bg |
+| FAIL-5 | User reports "I'm still on 0.1.5" when 0.1.6 was just deployed | Browser / userscript-manager / gist CDN cache | Bump version, append `?v=N` to raw URLs, force-update (Iron Law #5) |
+| FAIL-6 | Screenshot looks identical to the unstyled fixture | Stray backtick / template-literal syntax error in userscript | Run `scripts/screenshot.py` V8 pre-check before claiming the userscript runs (Iron Law #6) |
+
+## Decision Framework
+
+| Situation | Action | Invariant |
+|---|---|---|
+| User asks for dark mode / re-theme of an existing third-party site | Use layer-theme | — |
+| User references a previously named saved style ("apply the luci-dark-material style to X") | Use layer-theme; read the named spec under `themes/<name>.md` first | — |
+| User wants to author a design system inside a codebase they own | Skip — this skill is for sites you don't own | — |
+| About to claim "this looks fixed" | Render fresh PNG via `screenshot.py`, Read it before responding | INV-2 |
+| About to add a third `nth-child` selector | Stop, write a Phase 3 critique, refactor to class families | INV-4, INV-5 |
+| Adding a `filter:` rule to a parent of an interactive element | Switch to `color-mix()` on `background-color` | (Iron Law #7) |
+
+## Testing
+
+**Traceability:** INV-1 — structural — enforced by frontmatter validation in the dev-workflow-toolkit `quality-gate.sh` (`skill-structure` and `inv-numbering` checks). INV-2 through INV-5 — reasoning-required — enforced by the skill's Iron Laws and Phase gates; verified during code review and by repeated invocation against real third-party sites.
+
+Validate via manual invocation: trigger `layer-theme` against a real site, walk through the 6 phases, verify each Iron Law gate fires (no visual claim without a PNG read; no selectors before Phase 3 critique; no claim that a JS change "works" without a post-change PNG).
+
+## Dependencies
+
+| Dependency | Type | SPEC.md Path |
+|---|---|---|
+| Claude Code skill router | external | N/A — built into Claude Code runtime |
+| Read tool (Claude Code) | external | required for INV-2 PNG reads |
+| Playwright (Python) | external | runtime dependency, installed per-project |
+| Pillow (Python) | external | runtime dependency for screenshot.py image ops |
+| Tampermonkey / Greasemonkey / Stylus | external | end-user-installed userscript managers; not consumed by the skill itself |

--- a/plugins/web-ui-theming-tampermonkey/skills/SPEC.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/SPEC.md
@@ -32,7 +32,6 @@ A six-phase workflow gated by nine "Iron Laws" that turn visual claims from anal
 | YAML frontmatter `name: layer-theme` | Claude Code skill router | Unique, lowercase, matches directory name |
 | Phase 6 finalize step | The user, on completion | Produces a named theme spec under `themes/<name>.md` |
 | `themes/<name>.md` references | Future invocations like "apply the luci-dark-material style to grafana" | Self-contained palette + pattern library, readable by future skill invocations |
-| `scripts/screenshot.py` / `scripts/contrast.py` | Skill-internal Phase 5 verification | Run from a project's working directory; expects `theme-vendor/`, `fixtures/`, and a userscript file |
 
 ## Invariants
 
@@ -72,7 +71,7 @@ A six-phase workflow gated by nine "Iron Laws" that turn visual claims from anal
 
 ## Testing
 
-**Traceability:** INV-1 — structural — enforced by frontmatter validation in the dev-workflow-toolkit `quality-gate.sh` (`skill-structure` and `inv-numbering` checks). INV-2 through INV-5 — reasoning-required — enforced by the skill's Iron Laws and Phase gates; verified during code review and by repeated invocation against real third-party sites.
+**Traceability:** INV-1 — structural — enforced by frontmatter validation in the dev-workflow-toolkit `quality-gate.sh` (`skill-structure` check). INV-2 through INV-5 — reasoning-required — enforced by the skill's Iron Laws and Phase gates; verified during code review and by repeated invocation against real third-party sites.
 
 Validate via manual invocation: trigger `layer-theme` against a real site, walk through the 6 phases, verify each Iron Law gate fires (no visual claim without a PNG read; no selectors before Phase 3 critique; no claim that a JS change "works" without a post-change PNG).
 
@@ -83,5 +82,4 @@ Validate via manual invocation: trigger `layer-theme` against a real site, walk 
 | Claude Code skill router | external | N/A — built into Claude Code runtime |
 | Read tool (Claude Code) | external | required for INV-2 PNG reads |
 | Playwright (Python) | external | runtime dependency, installed per-project |
-| Pillow (Python) | external | runtime dependency for screenshot.py image ops |
 | Tampermonkey / Greasemonkey / Stylus | external | end-user-installed userscript managers; not consumed by the skill itself |

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/SKILL.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/SKILL.md
@@ -1,0 +1,362 @@
+---
+name: layer-theme
+description: Use when the user asks to dark-mode, restyle, re-theme, retone, skin, or layer a custom theme onto an existing website or web app — typically delivered as a Tampermonkey/Greasemonkey/Stylus userscript or a UserStyle. Also use when the user references a previously named saved style ("apply the luci-dark-material style to X") or asks for a Material/Fluent/etc. dark mode for a third-party site. Skip for native app theming, design-system authoring inside a codebase you control, or one-off CSS tweaks to your own page.
+---
+
+# Layer Theme
+
+Override the visual layer of a website you don't own — dark mode, brand
+re-tone, density adjustments — without forking the source. Deliverable is a
+**single userscript file** (or stylesheet) that the user installs via
+Tampermonkey / Greasemonkey / Stylus.
+
+The work is fundamentally **archaeological + visual**: read the upstream
+designer's intent from their CSS variables and class names, override at the
+right tier, and verify with screenshots that the result respects the
+underlying UX hierarchy rather than just patching individual selectors.
+
+## Iron Laws
+
+These are the failure modes this skill exists to prevent. They came from a
+single day of theming work that hit each one. Do not skip them.
+
+1. **Vendor the real CSS.** Never approximate the target's stylesheet. Save
+   it under `theme-vendor/` and link to it from your fixtures. Approximated
+   CSS produces approximated bugs.
+2. **Study before selecting.** Spend the first phase reading upstream's
+   custom-property API and class taxonomy. Almost every site has a public
+   `--var` API that re-tones half the UI for free if you override it. Find
+   it before writing selector rules.
+3. **Render gate (Playwright is mandatory).** No claim that a CSS or JS
+   change "works" without a fresh artifact from `scripts/screenshot.py`
+   produced *after* that change. Reasoning about cascade, selector
+   specificity, or what the rule "should" do does not satisfy this gate. If
+   the harness hasn't run since your last edit, you don't know yet.
+4. **Vision gate (Read the PNG).** No claim about how the rendered page
+   *looks* — alignment, contrast, "looks good now," "I see it" — without
+   having just used the Read tool on the relevant `screenshots/dark/*.png`
+   in this turn. Analytical reasoning about what the screenshot would
+   show is **not** a substitute for actually loading it. The cost of one
+   extra Read is ~zero; the cost of being wrong is the user typing
+   "why can't you see this?" for the third time. If you catch yourself
+   inferring visual outcomes from CSS rules instead of from a PNG, you
+   are violating this gate. See `references/vision-verification.md`
+   § "The overconfidence trap".
+5. **Cache-bust every iteration.** Browser cache, gist CDN, and userscript
+   manager update intervals all conspire against you. When the user reports
+   "I'm still on 0.1.5", they're not lying — bump version, append `?v=N` to
+   raw URLs, and tell them to force-update.
+6. **Parse-check the userscript before screenshotting.** A stray backtick
+   inside a CSS template literal will silently produce a screenshot that
+   looks identical to the unstyled fixture. Use the `scripts/screenshot.py`
+   pre-check that runs `new Function(body)` in V8 — it catches every syntax
+   error without executing the script.
+7. **Avoid stacking-context traps.** Properties like `filter`, `transform`,
+   `opacity < 1`, `will-change`, `mix-blend-mode`, `mask`, `clip-path`, and
+   `isolation: isolate` create a containing block for positioned descendants.
+   If a hover tooltip or dropdown lives inside the styled element, applying
+   `filter: saturate(.7)` to the element will clip the tooltip. Prefer
+   `color-mix()` on `background-color` over filter-based desaturation.
+8. **Element-level contrast, not background-level.** A button can be
+   "dark grey on dark page" — passing the page check while failing on
+   itself. The contrast pass must compare each text node's computed color to
+   its actual rendered background, not to the page bg.
+9. **Generality over specificity (the "don't whack-a-mole" rule).**
+   A theme's quality is measured by how *few* and how *general* its
+   rules are. Every site-specific selector — page IDs, `nth-child`
+   indexes, single-element targets — is debt. When the user says
+   something looks "half-baked," stop adding rules and produce a
+   critique document first; list principles (saturation, weight tier,
+   slot pattern, hover progression) and group findings under them.
+   When the user says something looks complex, refactor to use the
+   framework's class families before adding more selectors. The fix
+   list falls out of the principles, not the symptoms. See
+   `references/design-principles.md` § "Generality is a quality
+   metric".
+
+## When to use
+
+Trigger when the user asks for any of:
+
+- "Make a dark mode for `<site>`"
+- "Restyle / reskin / re-tone this web app"
+- "Tampermonkey theme", "Greasemonkey theme", "Stylus userstyle"
+- "Apply the `<saved-name>` style to `<new-site>`" (look in `themes/`)
+- "Theme this LuCI / Grafana / phpMyAdmin / etc. install"
+
+Do **not** trigger for: native-app theming (Electron-but-native count varies —
+ask), design-system authoring in a codebase the user controls (use
+`frontend-design`), or single-page CSS tweaks to a file the user owns.
+
+## The 6-phase workflow
+
+Each phase has a gate. Don't move on until the gate passes.
+
+### Phase 1 — Capture intent
+
+Ask, in one round, only what you can't infer:
+
+- **Site URL or live install** the theme should apply to.
+- **Goal:** dark mode, brand re-tone (which brand?), density, accessibility,
+  or pure aesthetic preference.
+- **Named-style reuse?** If the user says "use the X style", check
+  `themes/X.md` exists and load it as the design spec for this run. Skip the
+  study phase and go straight to fixture rig.
+- **Delivery format:** Tampermonkey/Greasemonkey userscript (most common,
+  ships JS too), Stylus userstyle (CSS-only), or a paste-into-DevTools
+  stylesheet.
+- **Browser access:** can you reach the live site, or only static HTML the
+  user pastes / saves? See `references/upstream-acquisition.md`.
+
+If the answers are obvious from context (e.g. user says "dark mode for my
+LuCI router"), don't interrogate — proceed.
+
+### Phase 2 — Acquire upstream
+
+Read `references/upstream-acquisition.md`. The short version:
+
+1. **Identify the upstream project.** Search GitHub / the site's source for
+   the actual theme repo (e.g. `luci-theme-material`, `grafana/grafana`).
+   Note the license — your output should match (Apache, MIT, etc.).
+2. **Look for an existing community theme.** Read
+   `references/existing-themes.md`. For popular sites (GitHub, YouTube,
+   Reddit, Twitter, Grafana, phpMyAdmin), there are mature dark themes on
+   userstyles.world / Stylus / Greasy Fork — fetch and study them as
+   reverse-engineered design references. Do not copy wholesale. Cite them
+   in the userscript header if used as inspiration.
+3. **Vendor the upstream CSS.** Download every stylesheet the site loads
+   into `theme-vendor/` (preserve filenames). Also vendor logos / icon SVGs
+   you'll need to invert. If the source is unreachable from the agent
+   environment, ask the user to save the page (Save Page As → Webpage,
+   Complete) and drop the resulting folder in.
+4. **Vendor representative HTML.** Pick 5–8 high-traffic pages and save
+   them as static fixtures under `fixtures/`. Strip dynamic JS; rewrite
+   `<link>` hrefs to point at `theme-vendor/`. The LuCI run vendored login,
+   overview, interfaces, firewall, system, UCI changes — small enough to
+   render quickly, broad enough to surface most components.
+
+**Gate:** the fixtures load and render in the browser without console errors,
+matching the live site's appearance pixel-roughly.
+
+### Phase 3 — Design study
+
+Read `references/design-principles.md`. Then:
+
+1. **Find the public CSS variable API.** Grep the upstream CSS for
+   `--`-prefixed custom properties. Most modern frameworks expose 20–60 of
+   them as the public theming contract — re-mapping these is Tier 1, the
+   highest-leverage work.
+2. **Find the hardcoded color literals.** Grep for `#[0-9a-f]{3,8}`, `rgb(`,
+   `rgba(` *outside* the variable definitions. These bypass the var system
+   and need direct selector overrides — Tier 2.
+3. **Find the class taxonomy.** Identify the framework's button/alert/input
+   class families (`btn-*`, `cbi-button-*`, `mat-flat-button`, etc.). They
+   are the targets for Tier 3 (semantic re-coloring).
+4. **Map elevation tiers.** Sites usually have 3–5 surface depths
+   (page bg, header/sidebar, card, hover row, selected row). Name them.
+5. **Inventory what's "half-baked".** Open the live light-mode site and
+   note papercuts unrelated to dark mode — center-aligned tabular data,
+   missing focus rings, illegible disabled states. Bundle these fixes;
+   reviewers value the polish.
+
+**Gate:** produce a `critique.md` (template in `templates/critique.md`) that
+lists every Tier 1 var, every Tier 2 literal range, every class family, and
+every papercut found. This is the design brief. Show it to the user before
+writing CSS.
+
+### Phase 4 — Fixture rig
+
+1. Copy `templates/userscript.user.js` to `<project>/dark-mode.user.js` (or
+   similar). Fill in the metadata block (`@match`, `@version`, `@homepageURL`).
+2. Copy `scripts/screenshot.py` to `<project>/scripts/`. The harness:
+   - Reads `dark-mode.user.js`, extracts the CSS template and the JS body
+     separately, runs a real V8 syntax check before doing anything else.
+   - Loads each fixture twice — light (no script) and dark (script injected
+     with a `GM_addStyle` polyfill that defers append until the parser has
+     created `documentElement`).
+   - **Renders every declared interactive state** (see step 4 below) for
+     each fixture, in both light and dark.
+   - Saves to `screenshots/{light,dark}/<label>.png` plus
+     `screenshots/{light,dark}/<label>--<state>.png` for each state.
+3. `uv venv && uv pip install playwright pillow && playwright install chromium`.
+4. **Declare interactive states for every fixture that contains
+   interactive elements.** Static screenshots alone are insufficient —
+   the LuCI Routing/NAT regression was visible only when a dropdown was
+   in its default-open state, and a similar bug in a hover-only state
+   would slip through entirely. For each fixture, add a
+   `<script id="layer-theme-states">` JSON block declaring the states to
+   capture (see `templates/fixture.html` for the full schema).
+   Coverage rule of thumb:
+   - For every hoverable element *type* in the fixture (button intent,
+     link, row, etc.), at least one hover state.
+   - For every focusable element type (input, select, textarea), at
+     least one focus state.
+   - For every disclosure widget (details/summary, dropdown, modal
+     trigger), at least one click-to-open state.
+   - At least one alternate viewport (mobile if responsive).
+   - Where the theme uses `@media (prefers-*)` queries, one state per
+     media value covered.
+5. Run the harness once before adding any theme rules. Confirm the
+   light and dark static images are identical and every declared state
+   captures cleanly (the userscript is a no-op at this stage).
+
+**Gate:** `python scripts/screenshot.py` produces a screenshot per
+fixture × {light, dark} × {static + every declared state}, all
+matching, no console errors. If a fixture has interactive elements but
+no declared states, that is an uncovered surface — add states or
+explicitly justify why the static state is sufficient.
+
+### Phase 5 — Write, screenshot, vision-verify, iterate
+
+This is the inner loop. **Read `references/vision-verification.md` first**
+— specifically § "The overconfidence trap" — and refresh it any time you
+catch yourself reasoning about CSS as a substitute for screenshotting.
+
+Two gates apply throughout this phase: the **render gate** (Iron Law #3)
+and the **vision gate** (Iron Law #4). Both are mechanical. Neither can
+be discharged by analysis.
+
+For each batch of changes:
+
+1. **Prefer one tier per batch.** Tier 1 changes (var-API remaps), Tier 2
+   (literal repaints), and Tier 3 (class semantics) each have different
+   blast radii and different failure modes. Doing a tier-at-a-time makes
+   regressions trivially attributable. Bundle across tiers only when
+   the changes are tightly coupled (a Tier-1 var rename that requires a
+   Tier-3 selector update to land together) — agent judgment, not a
+   hard rule. If you bundle and a regression appears, your bisect cost
+   is the price you pay; budget for it.
+2. **Re-run the screenshot harness — every batch, no exceptions.**
+   `python scripts/screenshot.py`. Render gate (#3): until this completes
+   for the current edit, you have no evidence the change rendered. *Do not*
+   reason from the diff to the visual outcome. Run the harness.
+3. **When a visual claim is needed, load the PNG.** Vision gate (#4):
+   any statement about how the page looks must be preceded by `Read
+   screenshots/dark/<label>.png` *in the same turn*. This includes
+   self-talk ("the sidebar should now…"). If you're tempted to skip the
+   Read because the change is "obvious," that is the overconfidence trap
+   and you must Read anyway. Compare to `screenshots/light/<label>.png`
+   side-by-side. Look for: text inside coloured backgrounds you forgot,
+   native widgets (checkbox, scrollbar, selection) still in light mode,
+   focus rings missing, status pills with insufficient contrast,
+   alignment changes, clipped tooltips.
+4. **Run the contrast check.** `scripts/contrast.py` (Playwright) walks
+   every text node in each fixture, reads computed color and effective
+   background, and flags pairs below WCAG AA (4.5:1 normal, 3:1 large).
+   Fix everything it flags before declaring the batch done. This is also
+   mechanical — *not* a substitute for the vision gate, which catches
+   issues contrast.py misses (alignment, layout breakage, missing
+   elements, layered z-index bugs).
+5. **Repeat until clean.**
+
+### When the user reports a regression
+
+A regression report is a signal worth more than the bug itself — it
+identifies a *class* of defect the rig didn't catch. Patching without
+classifying loses that signal.
+
+**Before patching, run the 4-branch assessment** in
+`templates/regression-assessment.md`. Copy it next to the project as
+`regression-<short-slug>.md` and fill it in. The branches:
+
+1. **1a — Vision saw it but didn't flag it** → add the missing check to
+   the per-fixture checklist in `references/vision-verification.md`.
+2. **1b — Vision didn't see it** → either fixture coverage gap (add a
+   fixture / page), state coverage gap (add an interactive state to the
+   fixture's `layer-theme-states` block), or vision-gate-skipped
+   (sharpen the gate language).
+3. **2 — Violates a general UX principle** → add the principle to
+   `references/design-principles.md` (or sharpen an existing entry that
+   was buried).
+4. **3 — User preference, not principle** → save as `feedback` memory,
+   *not* a principle.
+5. **4 — Site-specific corner case** → record in `themes/<style-name>.md`
+   gotchas, *not* the global skill.
+
+Then reproduce the regression in a fixture (or interactive state) and
+fix. A fixture for the bug stays as a regression test for future
+iterations. Add a one-line entry to `themes/<style-name>.md` under
+"Regressions caught" with date, branch, and where the fix propagated.
+
+This is the skill's self-improvement loop. Skipping it means the next
+theme — and the next user — meet the same failure mode.
+
+**Gate:** all fixtures pass vision review (you can describe them from a
+PNG you just Read, and they look intentional, not patched), and
+contrast.py reports zero failures.
+
+### Phase 6 — Finalize and name the style
+
+Once the user signs off ("looks much better"):
+
+1. **Generality self-check.** Read `references/design-principles.md` §
+   "Generality is a quality metric". Walk every rule in the userscript
+   and ask: *would this rule make sense on a different site that uses
+   the same framework family?* Flag every rule that targets a single
+   page ID, an `nth-child` index, a single text node, or other
+   site-specific debt. For each flagged rule, push it back to a Tier 3
+   class family if one exists; if none does, consider whether a small
+   JS tagger could *create* a class family (the
+   `data-action`/`data-luci-action` pattern in the template). The goal:
+   the smaller and more general the final ruleset, the more durable the
+   theme — and the cleaner the eventual saved style spec.
+2. **Code-simplification pass.** Read `references/design-principles.md` §
+   "Simplification". Common reductions: collapse over-specific selector
+   chains (`table > tbody > tr > td` when `tr > td` already wins), merge
+   per-intent button rules into slot patterns (`--btn-bg/fg/bd/hover`),
+   replace scattered font-weight literals with three named tiers, replace
+   hardcoded transition durations with one token. Re-screenshot after each
+   reduction; revert any that break visuals.
+3. **Save the named style.** Copy `templates/theme-spec.md` to
+   `themes/<style-name>.md` (kebab-case, descriptive — `luci-dark-material`,
+   `grafana-mono-amber`). Fill in the palette, weight tiers, slot patterns,
+   elevation tiers, status semantics, focus-ring spec, and any
+   site-agnostic principles that came up. The theme-spec is the
+   reusable artifact; the userscript is the site-specific instance.
+4. **Save a memory pointer.** Write a `reference`-type memory entry in the
+   user's memory system pointing at the saved theme spec, so future
+   conversations can find it by name. Format:
+   ```
+   - [Saved theme: <name>](theme_<name>.md) — <one-line aesthetic summary>
+   ```
+5. **Ship the userscript.** If publishing as a gist, use a versioned URL
+   so the userscript manager auto-updates. Tell the user to bump the
+   `@version` and append `?v=N` to the raw URL the first time, since
+   the gist CDN caches aggressively.
+
+**Gate:** `themes/<name>.md` exists, the userscript ships, the memory
+pointer is saved.
+
+## Reusing a saved style
+
+When the user says "apply the `<name>` style to `<new-site>`":
+
+1. Read `themes/<name>.md` — this is the design spec.
+2. Skip Phase 3 (study); go straight to Phase 4 (fixture rig) using the new
+   site's CSS, applying the spec's palette and patterns.
+3. Don't expect a clean port. Sites have different class taxonomies, and
+   you'll still spend Tier 2 work on the new site's hardcoded literals. But
+   the palette / weight tiers / slot patterns transfer directly.
+
+## Outputs
+
+By the end of a successful run, you've produced:
+
+- `<project>/dark-mode.user.js` (or similar) — the deliverable.
+- `<project>/theme-vendor/` — vendored upstream CSS + assets.
+- `<project>/fixtures/*.html` — synthetic test pages.
+- `<project>/scripts/screenshot.py` + `contrast.py` — the test rig.
+- `<project>/screenshots/{light,dark}/` — baseline visuals.
+- `<project>/critique.md` — the Phase-3 design brief.
+- `themes/<name>.md` (in this skill's directory) — the reusable style spec.
+- A memory pointer.
+
+## See also
+
+- `references/upstream-acquisition.md` — vendoring + asking the user.
+- `references/design-principles.md` — the principles checklist.
+- `references/vision-verification.md` — Claude Vision protocol.
+- `references/existing-themes.md` — community theme sources for popular sites.
+- `templates/critique.md`, `templates/theme-spec.md`, `templates/userscript.user.js`, `templates/fixture.html`.
+- `scripts/screenshot.py`, `scripts/contrast.py`.
+- `themes/` — the named-style catalog. Browse it before starting; reuse beats reinvention.

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/references/design-principles.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/references/design-principles.md
@@ -1,0 +1,301 @@
+# Design principles
+
+The checklist that the LuCI session surfaced as load-bearing. Every rule
+here exists because skipping it produced a regression or a "half-baked"
+critique. Read at the start of Phase 3.
+
+## Generality is a quality metric
+
+A theme is *better* the more general its rules are. Specific rules
+("`#admin-status-overview .ifacebox-head` should be light") work today
+but rot the moment upstream renames a class. General rules ("text
+inside coloured fills uses the matching `--on-*` token") survive
+upstream churn, transfer to other sites, and produce a smaller
+maintenance surface.
+
+This is the single most important principle in this file. Every other
+rule below is in service of generality:
+
+- **Tokens over literals** — one palette change re-tones the whole UI.
+- **Slot patterns over per-intent rules** — adding a new button intent
+  is a one-line addition, not a new rule block.
+- **Class-family selectors over single-element selectors** — `.btn-*`
+  catches every button intent at once.
+- **Framework-aware tiers (1/2/3)** — work with the framework's design
+  language, not against it.
+
+**Phase 6 self-test.** Before declaring the theme done, walk every rule
+and ask: *would this rule make sense on a different site that uses the
+same framework family?* If the answer is no — if you have selectors
+that target a single page, a single ID, an `nth-child` index, or a
+specific text node — that's site-specific debt. Push it back to Tier 3
+where possible: find the class family the framework already provides
+and use it. If no class family exists, that's a signal to consider a
+small JS tagger (the "semantic-attribute tagger" pattern in the
+template) that *creates* a class family — generalising once at the JS
+boundary instead of repeating site-specific selectors.
+
+The LuCI session converged to a complex solution before refactoring it
+back to general principles. The user explicitly asked to "study the
+source code…to understand the intent of the web designers on how
+consistent colors should flow through the design. Doing this may help
+us vastly reduce the complexity of this theme." That instruction was
+right; bake it in.
+
+**Counter-pattern to recognize.** If you find yourself adding a fourth
+or fifth selector for the same logical concept, stop. The framework
+has a class family for this. Find it. If you can't find one, check
+whether the upstream theme inherits from a known framework
+(Bootstrap, Material, Bulma) — those families propagate through.
+
+## The two-tier override architecture
+
+Modern frameworks expose a public CSS-variable API but also bake hardcoded
+color literals into the cascade. Override at both tiers.
+
+**Tier 1 — Public variable API.** Re-map the framework's `--color-*` /
+`--mdc-theme-*` / `--ant-primary-color` etc. to your dark tokens. This
+re-tones every selector that uses `var(--*)`, which is usually the
+majority. Highest leverage; do this first.
+
+**Tier 2 — Hardcoded literals.** Grep upstream for `#[0-9a-f]+`, `rgb(`,
+`rgba(` *outside* `:root` definitions. Those bypass the var system. Hit
+them with semantic selector groups (page bg, card surface, table stripe,
+code block, etc.).
+
+**Tier 3 — Class taxonomy semantics.** The framework's button/alert/input
+class families need to be re-coloured in your dark palette while preserving
+the original *intent* (action vs. neutral vs. destructive vs. status).
+
+## Tokens you should always define
+
+Don't scatter colors across the file. Define a `:root` token block at the top.
+
+```css
+:root {
+  /* Surfaces — 4–5 elevation tiers for visual depth */
+  --bg:        #121417;  /* page */
+  --bg-1:      #1a1d22;  /* sidebar / header / footer */
+  --bg-2:      #21252b;  /* card / panel / modal */
+  --bg-3:      #2d3239;  /* hover row, alt-row, dropdown */
+  --bg-4:      #393f48;  /* selected / focused */
+  --bg-code:   #0c0e11;  /* code blocks, terminals */
+
+  /* Text — primary / secondary / tertiary */
+  --fg:        #e6e8eb;  /* ~14:1 on bg */
+  --fg-2:      #a4a9b0;  /* ~7.5:1 secondary */
+  --fg-3:      #6c7178;  /* disabled, large UI only — fails AA on small text */
+  --fg-link:   #4ad0f4;
+
+  /* Borders — visible, not ghosted */
+  --border:    #363b43;
+  --border-2:  #444a54;  /* stronger for inputs / focus rings */
+  --shadow:    rgba(0,0,0,0.45);
+
+  /* Accent — site brand, lifted into dark-friendly territory */
+  --accent:     #22c1f0;
+  --accent-2:   #4ad0f4;
+  --accent-dim: #155a72;
+  --on-accent:  #062330;  /* dark text on bright accent, ~9:1 */
+
+  /* Status — paired with on-* tokens that pass AA on the fill */
+  --success:    #5ec979;  --on-success: #0a1d10;
+  --warning:    #f1c453;  --on-warning: #2a1e00;
+  --danger:     #e57373;  --on-danger:  #2a0d0d;
+
+  /* Tonal surfaces — color-mix() tracks the accent if user customizes it */
+  --accent-tonal-bg:  color-mix(in srgb, var(--accent) 14%, transparent);
+  --accent-tonal-bd:  color-mix(in srgb, var(--accent) 35%, transparent);
+
+  /* Font-weight — three semantic tiers, NOT scattered literals */
+  --fw-body:   400;  /* body / ambient */
+  --fw-medium: 500;  /* interactive: buttons, active sidebar/tab, h1–h3 */
+  --fw-bold:   600;  /* small-text emphasis: chips, pills, labels at <13px */
+
+  /* Single transition token — uniform interaction feel */
+  --trans: 150ms ease;
+}
+```
+
+The named-style memory writes this exact structure. When reusing a saved
+style for a new site, copy the token block and Tier-1 override block;
+Tier-2/3 selectors are site-specific.
+
+## Contrast (WCAG AA, non-negotiable)
+
+- Body text vs. its background ≥ **4.5:1**.
+- UI text ≥ 18px or ≥ 14px bold ≥ **3:1** ("large text" exemption).
+- Non-text UI (icons, focus rings, status indicators) ≥ **3:1** vs. their
+  surroundings.
+- Disabled text is exempt — but make it visibly disabled, not just dim.
+
+**Status colors on dark.** White text on `#5cb85c` / `#d9534f` / `#f0ad4e`
+fails AA at 2.4–3.7:1. Switch to dark text on the bright fill (`#0a1d10` on
+green, `#2a0d0d` on red, `#2a1e00` on yellow) — passes at 7:1+.
+
+**Element-level, not page-level.** A button can be "dark grey on dark page,"
+passing the page bg check while failing on itself. Use `scripts/contrast.py`
+which walks every text node.
+
+**`color-mix` tonal backgrounds.** When you want a 14%-tinted surface for
+sidebar-active or alert-info, derive it via `color-mix(in srgb, var(--accent)
+14%, transparent)` rather than hardcoding `rgba(34,193,240,0.14)`. Tonal
+surfaces then track the accent automatically when the palette is customized.
+
+## Alignment / typography (the "papercut" checklist)
+
+These are upstream UX papercuts — not strictly dark-mode work, but bundle
+them. Reviewers value the polish.
+
+- **Tabular data left-aligned.** Many themes apply `text-align: center
+  !important` to every section-table cell. IPs, MACs, names, status text
+  become unscannable. Override to left; keep action columns right-aligned;
+  centre only single-icon button cells.
+- **Column titles bold + left-aligned.** Aligned with the values they label.
+- **Three-tier font-weight system.** Body (400) / interactive (500) /
+  emphasis (600). Don't scatter literal `font-weight: 500` across 7
+  selectors — name them.
+- **Consistent transitions.** One `--trans: 150ms ease` token, applied to
+  every interactive surface. Mismatched durations feel cheap.
+- **Visible focus rings.** `:focus-visible { outline: 2px solid
+  var(--border-2); outline-offset: 2px; }` on every interactive element.
+  Even on mouse-only sites — keyboard users exist.
+- **Keep scoped link colors.** Do **not** write `a { color: ... }` without a
+  scope or `:not()` — you'll override sidebar/tab/breadcrumb link styles
+  that the upstream theme defines specifically. Default unscoped `<a>`
+  fall back to browser blue (`#0000EE`) which is unreadable on dark, so a
+  reset is needed, but limit it: `body :not(.btn):not(.menu-item) > a`.
+
+## Button slot pattern (kills duplicate rules)
+
+Don't define five separate rule blocks for `cbi-button-action`,
+`-apply`, `-reset`, `-remove`, `-neutral`. Define a single slot and let
+each intent class set the slot values.
+
+```css
+.btn {
+  background: var(--btn-bg);
+  color: var(--btn-fg);
+  border: 1px solid var(--btn-bd);
+  transition: background var(--trans), color var(--trans);
+}
+.btn:hover { background: var(--btn-hover, var(--btn-bg)); }
+
+.btn-action  { --btn-bg: var(--accent);  --btn-fg: var(--on-accent);  --btn-bd: var(--accent); }
+.btn-apply   { --btn-bg: var(--success); --btn-fg: var(--on-success); --btn-bd: var(--success); }
+.btn-remove  { --btn-bg: var(--danger);  --btn-fg: var(--on-danger);  --btn-bd: var(--danger); }
+.btn-neutral { --btn-bg: var(--bg-2);    --btn-fg: var(--fg);         --btn-bd: var(--border-2); }
+```
+
+Same trick for alerts, input states, badges. Cuts the file by ~40%.
+
+## Stacking-context traps
+
+These properties create a containing block for absolutely-positioned
+descendants. Never apply them to an element whose hover tooltip or
+dropdown menu is positioned by being placed inside it:
+
+- `filter` (any value, including `filter: saturate(0.7)`)
+- `transform` (any value)
+- `opacity < 1` (yes, even 0.99)
+- `will-change`
+- `mix-blend-mode`
+- `mask`, `clip-path`
+- `isolation: isolate`
+- `perspective`
+
+The LuCI run hit this: zone-badges desaturated with `filter: saturate(.7)
+brightness(.88)` worked great visually, but the firewall-zone hover tooltip
+sat inside the badge in the DOM, and the filter clipped it. Fix: replace
+filter with a `color-mix()` on the background:
+
+```css
+/* BAD — creates stacking context */
+.zone-badge { filter: saturate(0.7) brightness(0.88); }
+
+/* GOOD — same visual, no stacking context */
+.zone-badge {
+  background-color: color-mix(in srgb, var(--zone-color) 70%, var(--bg-2));
+}
+```
+
+## Hover state progression
+
+A consistent vocabulary:
+
+- **Tonal → filled** for primary actions (subtle bg → coloured bg on hover).
+  Promises actionability without shouting.
+- **Brightness up** for filled buttons (`filter: brightness(1.06)` works
+  here because buttons rarely contain positioned descendants — verify).
+  Or use `*-hi` token: `--success-hi: #4eb869`.
+- **Background +1 tier** for navigation and rows (`bg → bg-3` on hover).
+- **Underline** on text-only links — never colour-shift.
+
+## Sidebar / tab active state
+
+The "modern Material You / Fluent" pattern:
+
+- 3px accent stripe on the leading edge.
+- Tinted background (`var(--accent-tonal-bg)` ≈ 14% accent over surface).
+- Text in primary `--fg`, weight `--fw-medium`.
+- Hover state for inactive items: bg-3, no stripe.
+
+Avoid: solid-colour active blocks (looks dated), or no visual change at all.
+
+## Native widget harmonization
+
+Browsers render these in light mode by default unless told otherwise:
+
+- `<input type="checkbox" / radio>` → set `accent-color: var(--accent)`.
+- Selection highlight → `::selection { background: var(--accent-dim);
+  color: var(--fg); }`.
+- Scrollbar (Chromium) → `::-webkit-scrollbar { background: var(--bg-1); }`
+  + `::-webkit-scrollbar-thumb { background: var(--border-2); }`.
+- `<details>` triangle, `<input type="date">` calendar — these are vendor
+  UA chrome and may resist theming. Use `color-scheme: dark` on `:root`
+  to flip browser-controlled UI.
+
+## Icon visibility
+
+Sidebar carets, logout glyphs, status icons that are dark SVG-on-dark:
+- If they're inline SVG with `currentColor`, set the parent's `color`.
+- If they're `<img>` of dark SVG/PNG, `filter: invert(1) hue-rotate(180deg)`
+  is a quick fix. (Yes, `filter` — but `<img>` rarely contains positioned
+  descendants, so it's safe here.)
+- Better: vendor a copy of the icon and tweak its fill, or replace with a
+  CSS background using `mask-image`.
+
+## Responsive / media-query gotcha
+
+Toggling `display` on a pseudo-element inside a media query can drop the
+`content` property. If `::before` works on desktop but vanishes on mobile,
+restate `content`:
+
+```css
+@media (max-width: 600px) {
+  .header::before {
+    content: 'Menu';   /* upstream may have set this only at >600px */
+    display: block;
+  }
+}
+```
+
+## Simplification (Phase 6 pass)
+
+Common reductions that are safe:
+
+1. **Over-specific selector chains.** `table > tbody > tr > td` collapses to
+   `tr > td` if specificity already wins. Verify with screenshots.
+2. **Duplicated intent rules → slot pattern** (see button slot above).
+3. **Hardcoded weights → named tiers.** `font-weight: 500` × 7 → `var(--fw-medium)`.
+4. **Hardcoded transitions → single token.**
+5. **Hardcoded rgba() shadows / tints → color-mix() over tokens.**
+
+Common reductions that are **unsafe** without verification:
+
+- **Hedged selectors** (`.input:focus` AND `.input-text:focus`) when the
+  framework applies the latter class to non-`<input>` widgets. Run the full
+  screenshot suite and the contrast pass after removal; revert if anything
+  regresses.
+- **!important removal** — `!important` was usually added because something
+  else won. Remove only if you can prove nothing relies on the precedence.

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/references/existing-themes.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/references/existing-themes.md
@@ -1,0 +1,111 @@
+# Existing themes — reverse-engineering reference
+
+Before writing anything original, check whether a mature community theme
+already exists for the target site. Even when you don't reuse the code, the
+*design choices* — palette, weight tiers, focus styles — are useful learning
+data.
+
+## Where to look
+
+### Userstyles.world (Stylus userstyles, the modern home)
+
+`https://userstyles.world` — search by site domain. Output is CSS-only
+(Stylus / xStyle), no JS. Filter by:
+- Most installs
+- Recently updated (anything older than ~2 years probably broke)
+
+### Greasy Fork (userscripts, includes themes)
+
+`https://greasyfork.org/en/scripts?q=<site-domain>+dark` — userscripts that
+ship CSS via `GM_addStyle`. Many "dark mode" entries here. License usually
+visible on the script page.
+
+### GitHub topic search
+
+`https://github.com/topics/userstyle` and `https://github.com/topics/dark-mode`,
+plus `<site-name>-dark` repo names. Often higher-quality than userstyles.world
+because they're under version control with PRs and issues.
+
+### catppuccin / nord / gruvbox port projects
+
+Three palette communities maintain ports across hundreds of apps:
+- `https://github.com/catppuccin/catppuccin` — directory of all ports
+- `https://github.com/nordtheme/nord` and individual `nord-<app>` repos
+- `https://github.com/morhetz/gruvbox-contrib`
+
+If your target is in one of these directories, *use the port as a palette
+reference* even if you're delivering a different visual style.
+
+### Stylus/Stylish marketplace mirrors (legacy)
+
+`userstyles.org` is the old home; many themes there are abandoned. Check
+the install count and last-updated date before trusting them.
+
+## What to extract from a community theme
+
+Don't copy verbatim — but read with these questions in mind:
+
+1. **What palette do they use?** Often community themes converge on one of
+   ~10 well-known palettes (Material Dark, Dracula, Nord, Catppuccin,
+   Gruvbox, Tokyo Night, One Dark, GitHub Dark, Solarized Dark). If two
+   independent themes for your target use the same palette, that's a
+   strong signal.
+2. **Which CSS variables do they re-map?** If three themes for the same
+   site re-map the same 8 vars, those 8 vars are the public API. Save you
+   30 minutes of grep.
+3. **Which selectors do they hit at Tier 2?** Each one is a hardcoded
+   literal in the upstream cascade — your override list bootstrap.
+4. **What papercuts do they fix?** Compare to the `design-principles.md`
+   checklist. If three themes all bold the column titles, the upstream
+   light theme is wrong about column titles.
+5. **What do they leave broken?** Look for issues filed against the theme.
+   "Hover tooltip clipped" → stacking-context trap. "Status pills illegible"
+   → contrast on filled bg.
+
+## Sites with strong existing theme ecosystems
+
+If your target is one of these, *always* check before starting:
+
+| Target | Where |
+|---|---|
+| GitHub | userstyles.world / `darkreader` exception lists / GitHub's own dark themes |
+| YouTube | Greasy Fork (search "youtube dark") |
+| Reddit (old / new / sh) | `RES`, `Reddit Enhancement Suite`, plus userstyles |
+| Twitter / X | Greasy Fork |
+| Stack Overflow | Stack Apps |
+| Discord (web) | BetterDiscord themes (CSS), even though we're not theming the desktop app |
+| Grafana | `github.com/grafana/grafana` already ships dark; for *light*-mode polish look for community themes |
+| phpMyAdmin | userstyles.world; also bundled themes in the `themes/` directory of phpmyadmin source |
+| Jenkins | "dark-theme" plugin (built-in) — exemplary CSS to study |
+| Jellyfin / Sonarr / Radarr / -arr stack | Active theming community on Reddit r/jellyfin, custom CSS files |
+| OpenWrt LuCI | This skill's `themes/luci-dark-material.md` (first finalized) |
+
+## Sites that resist external theming
+
+When the user wants a theme for one of these, set expectations:
+
+- **Tailwind utility-only sites** — no var API, every rule needs `!important`.
+- **Heavily Shadow-DOM-walled apps** (some Lit-based components, web-components-heavy)
+  — `:host` selectors require `::part()` or theme-attribute hooks the app must expose.
+- **Apps that reload CSS on route change** (some SPAs) — your overrides
+  may need a MutationObserver to re-apply.
+- **Sites behind aggressive CSP** — if `<style>` injection is blocked,
+  Tampermonkey's `GM_addStyle` may fail silently. Test early.
+
+In all of these cases, also check Dark Reader's exception lists — they
+cover the ones where naive CSS overrides don't work.
+
+## Citing inspiration
+
+If a community theme materially informed yours (palette, structural
+choices), cite it in the userscript header:
+
+```js
+// @description  Dark theme for Acme. Palette inspired by acme-dracula
+//               (https://userstyles.world/style/12345/acme-dracula by @user, MIT).
+```
+
+Match license. If they're MIT and your project is Apache-2.0, that's
+compatible (Apache is more permissive in spirit, and MIT can be folded in
+with attribution). If they're GPL, your script becomes GPL too — confirm
+this is acceptable to the user before proceeding.

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/references/upstream-acquisition.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/references/upstream-acquisition.md
@@ -1,0 +1,151 @@
+# Upstream acquisition
+
+How to get the source, the rendered HTML, and the assets you need to theme a
+site you don't own. Read once at the start of Phase 2.
+
+## Three acquisition modes, in order of preference
+
+### Mode A — Public source (best)
+
+The site is open-source and the theme lives in a repo you can clone.
+
+Examples: OpenWrt LuCI (`github.com/openwrt/luci`), Grafana
+(`github.com/grafana/grafana`), phpMyAdmin, Mastodon admin, Forgejo,
+Gitea, Nextcloud.
+
+```bash
+gh repo clone <owner>/<repo> /tmp/<repo>
+# or shallow:
+git clone --depth=1 https://github.com/<owner>/<repo> /tmp/<repo>
+```
+
+Locate the theme/CSS subtree. Common locations:
+- `themes/<name>/htdocs/luci-static/<name>/css/`
+- `public/build/_assets/`
+- `frontend/src/styles/`
+- `assets/css/`
+
+Copy the compiled stylesheet and any logo / icon assets into your project's
+`theme-vendor/`. Do **not** vendor source SCSS/LESS — vendor what the browser
+actually loads, so your fixture renders the same selectors at the same
+specificity as production.
+
+Note the license. Your output's `@license` should match.
+
+### Mode B — Live HTTP fetch
+
+The site is reachable but the source is closed (or the CSS is built/minified
+in a way that makes the source unhelpful).
+
+```bash
+# Identify the loaded stylesheets
+curl -s https://example.com/some/page | \
+  grep -oE '<link[^>]+rel="stylesheet"[^>]*>' | \
+  grep -oE 'href="[^"]+"'
+
+# Vendor each one
+curl -s https://example.com/path/to/style.css -o theme-vendor/style.css
+
+# Vendor a representative page as a fixture
+curl -s https://example.com/some/page -o fixtures/some-page.html
+# Then hand-rewrite the <link> hrefs in the fixture to relative paths
+```
+
+Run a Playwright session against the live site to capture the *resolved*
+asset list (including dynamically-injected stylesheets):
+
+```python
+from playwright.sync_api import sync_playwright
+with sync_playwright() as p:
+    page = p.chromium.launch().new_page()
+    page.goto("https://example.com/some/page")
+    for s in page.evaluate("[...document.styleSheets].map(s => s.href).filter(Boolean)"):
+        print(s)
+```
+
+### Mode C — Ask the user (when blocked)
+
+Triggers:
+- The site requires auth and you can't see logged-in pages.
+- The site is on the user's private network (router admin, NAS, internal
+  Grafana) and the agent can't reach it.
+- The site is built behind aggressive anti-scraping (Cloudflare challenge,
+  bot detection) and curl returns junk.
+- The CSS is keyed by request and `curl` returns a different bundle than
+  the browser does.
+
+What to ask for, in priority order:
+
+1. **A "Save Page As → Webpage, Complete" dump** of one or two
+   representative pages. This gives you the exact HTML and every
+   stylesheet the browser actually downloaded, all in a single folder.
+2. **Failing that, devtools paste:** "open DevTools → Sources →
+   right-click each .css under `(index)` → Save As, and zip them up". Plus
+   the Elements panel "Edit as HTML" of the page wrapper.
+3. **Failing that, screenshots only:** if the user can't extract source at
+   all, take detailed light-mode screenshots and ask for the rendered
+   computed styles of a few representative elements (button, header, card,
+   table row, alert) via DevTools → Computed pane copy.
+
+Phrase the ask concretely. **Bad:** "can you send me the HTML?" **Good:**
+
+> I can't reach the site directly. Could you:
+> 1. Open the page at `<URL>` in your browser
+> 2. File → Save Page As → "Webpage, Complete" → save to a folder
+> 3. Drop the resulting `.html` file *and* its `_files/` directory into
+>    this project under `vendored-from-user/`
+>
+> This gives me the exact CSS the browser sees, including any auth-gated or
+> dynamically-loaded styles.
+
+If the site is large, ask for 5–8 specific page types: login, primary
+overview/dashboard, a list view, a detail/edit form, a settings page, an
+error/empty state, plus mobile if responsive.
+
+## Vendor-directory hygiene
+
+```
+project/
+├── theme-vendor/         # original CSS, untouched, do not edit
+│   ├── cascade.css       # the main stylesheet
+│   ├── custom.css        # the public theming API (if exposed)
+│   ├── logo.svg
+│   └── icons/
+│       └── ...
+├── fixtures/             # hand-built or saved HTML pages
+│   ├── login.html
+│   ├── _partials.js      # shared bits (header markup, etc.)
+│   └── ...
+└── theme-vendor.LICENSE  # copy of upstream license, with a note about origin
+```
+
+Rules:
+- Don't edit `theme-vendor/`. If you patch upstream CSS in your fixture, the
+  patch silently changes what production looks like.
+- Track `theme-vendor/` in git. Reproducible visual diffs across machines
+  require pinned upstream CSS.
+- Note the upstream commit/version somewhere (`theme-vendor.VERSION` or a
+  comment at the top of each vendored file).
+
+## Identifying the framework
+
+Before writing any CSS, identify what the site is built on. The variable API
+and class taxonomy depend heavily on this:
+
+| Hint in HTML/CSS | Likely framework |
+|---|---|
+| `cbi-*`, `cascade.css`, `data-page="admin-*"` | OpenWrt LuCI |
+| `mat-*`, `mdc-*`, `--mdc-theme-*` | Material / Angular Material |
+| `mui-*`, `MuiButton-*` | MUI (React) |
+| `ant-*`, `--ant-primary-color` | Ant Design |
+| `chakra-*` | Chakra UI |
+| `ph-*`, `phpmyadmin` markers | phpMyAdmin |
+| `grafana-app`, `panel-content` | Grafana |
+| `bootstrap` markers (`btn`, `navbar`, `container-fluid`, `col-*`) | Bootstrap |
+| `tailwind` (utility-class-only HTML) | Tailwind — much harder to theme externally; flag this to user |
+| `--joy-*` | Joy UI |
+
+If the framework is Tailwind utility-only, warn the user: there's often no
+useful var API, and you'll be fighting `!important` on every rule. Sometimes
+the right answer is a heavy preamble that re-defines the colors, sometimes
+it's "this isn't a good candidate for external theming."

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/references/vision-verification.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/references/vision-verification.md
@@ -1,0 +1,268 @@
+# Vision verification
+
+The protocol that prevents the failure mode the user surfaced as
+"Why can't you see them? What else can't you see?". Read before Phase 5.
+
+## The overconfidence trap
+
+This section exists because Opus's analytical capabilities are tempting
+but lossy for visual claims. The model defaults to reasoning when it
+should default to looking. **Reasoning about a screenshot is not a
+substitute for taking and loading one.**
+
+You are in the trap if you find yourself thinking, writing, or saying:
+
+- "Specificity-wise, this rule should win, so..."
+- "Given the cascade, the button will now be..."
+- "The change is small / obvious / mechanical, so I don't need to verify..."
+- "Earlier screenshots passed, so this similar change..."
+- "I can tell from the diff that..."
+- "The CSS reads correctly, therefore..."
+- "Tracing through the rules: ..."
+
+Every one of these substitutes a *model of the visual* for the *visual
+itself*. A model can be wrong. A PNG loaded into vision context cannot
+disagree with what the page actually rendered.
+
+**Decision rule.** When you want to make any claim about how something
+*looks* — alignment, contrast, color, focus state, spacing, "this fixed
+it," "this didn't change anything else" — there are exactly two valid
+moves:
+
+1. **Run Playwright** (`scripts/screenshot.py`) to produce a fresh
+   screenshot of the post-edit state.
+2. **Read the PNG** (Read tool on `screenshots/dark/<label>.png`) so it
+   enters vision context this turn.
+
+Both. In that order. Then write the claim, citing what you actually
+observed in the image.
+
+If you skip either step and the user catches the regression, that is the
+exact failure mode that produced the LuCI session's escalation: "Why
+can't you see them? Why are there pages you are unable to test?"
+
+The vision API call is **definitive**. The analytical chain is
+**probabilistic**. They are not equivalent. A screenshot taken and read
+costs ~zero; being wrong about a visual claim costs the user's trust.
+
+## Why this protocol exists
+
+Theme work is *visual*. Every textual proxy — selector chains, CSS rules,
+contrast math — can pass while the rendered output still looks broken.
+And in the LuCI run the user repeatedly caught issues that the agent had
+"verified" without actually loading the screenshot into vision context.
+
+The fix is mechanical: every iteration ends with the agent loading the dark
+screenshots as image content (not paths in prose) and reporting what they
+show. If the screenshot doesn't appear in your vision context, you have not
+verified it.
+
+## When the render gate applies (always, after any edit)
+
+After **every** edit to the userscript or a fixture, before any claim
+about whether the change works:
+
+```bash
+python scripts/screenshot.py
+```
+
+The harness's V8 syntax pre-check + the produced PNGs are the artifacts
+that discharge Iron Law #3. The PNGs alone, without the syntax check, do
+not — a stray backtick would yield identical-looking baselines.
+
+## When the vision gate applies
+
+Always, when making a claim about visuals. Never optional. Specifically:
+
+- After every screenshot run, before saying "the change rendered correctly".
+- After a regression report, before saying "I reproduced it" or "I fixed it".
+- Before declaring a fixture done, an iteration done, the theme done.
+- When the user pushes back on a visual point — Read the PNG *again*; the
+  prior reading is in a previous turn and is not in your current context.
+
+When the vision gate does **not** apply:
+
+- Mechanical work: editing CSS rules, refactoring selectors, renaming
+  tokens. (But the next claim about the result requires the gate.)
+- Pure logic: contrast.py output is structured, parseable text — read it
+  directly without a PNG. (But contrast.py is not a substitute for the
+  vision gate; it covers a strict subset of visual issues.)
+
+## The vision pass
+
+After every screenshot run, for each fixture **and each declared
+interactive state of that fixture**:
+
+1. **Read the dark image.** Use the Read tool on
+   `screenshots/dark/<label>.png` and on each
+   `screenshots/dark/<label>--<state>.png`. The tool returns image
+   content directly into context — this is how Claude actually sees it.
+2. **Read the light image too** for the same fixture/state pair. Visual
+   diff is the sharpest tool you have.
+3. **Walk the checklist below**, written into the response *as you look*,
+   not after.
+
+**The vision gate applies per state, not per fixture.** A static
+screenshot passing does not discharge the gate for a hover, focus, or
+modal-open state of the same fixture. The Routing/NAT Offloading
+regression slipped because the dropdown was visible by default; if the
+state had instead been hover-only and we had only checked the static
+PNG, we'd have shipped the regression. Don't.
+
+If a state's PNG was not produced (the fixture didn't declare it), that
+is a *coverage gap*, not a free pass — escalate via the regression
+assessment Branch 1b in `templates/regression-assessment.md`.
+
+## Per-fixture checklist (run for each)
+
+For each rendered page, check:
+
+### Surfaces & depth
+
+- [ ] Page bg is the deepest tier (`--bg`, ~`#121417`).
+- [ ] Header / sidebar / footer are `--bg-1`, visibly darker than `--bg-2`
+  cards but lighter than `--bg`.
+- [ ] Cards, modals, dropdown popovers sit on `--bg-2`, with a 1px
+  `--border` outline so they read as raised.
+- [ ] No "white box" surprise — every region has been re-toned.
+
+### Text
+
+- [ ] All body text is `--fg` (~14:1 against its bg).
+- [ ] Secondary / muted text is `--fg-2` (~7.5:1) — visibly distinct from
+  primary, but legible.
+- [ ] No `--fg-3` on small text (it fails AA below 18px).
+- [ ] Text inside coloured fills (status pills, accent buttons) uses the
+  matching `--on-*` token, not `--fg`.
+- [ ] No legacy browser-blue link (`#0000EE`) anywhere.
+
+### Interactive states
+
+- [ ] Buttons have visible borders or a tonal bg (not invisible).
+- [ ] Active sidebar / tab item has the accent stripe + tonal bg + bold
+  weight pattern.
+- [ ] Hover state visible on at least row hover and button hover.
+- [ ] Focus ring is visible — Tab through the page mentally and confirm
+  every interactive target shows a `--border-2` outline.
+- [ ] Native checkboxes / radios pick up `accent-color`.
+
+### Status / colour
+
+- [ ] Success / warning / danger fills carry their `--on-*` text colour
+  (dark text on bright fill is the WCAG-AA-passing pattern).
+- [ ] Status pills don't look pastel-out-of-place against the dark page —
+  they should read as saturated, not greyed-out.
+- [ ] Code blocks / terminal output use `--bg-code` (deepest), monospace.
+
+### Stacking / overlays
+
+- [ ] Hover tooltips render fully, aren't clipped.
+- [ ] Dropdown popovers escape their parent card.
+- [ ] Modal overlays cover the full viewport with `--shadow` scrim.
+- [ ] Z-index order: modal > dropdown > tooltip > toast > sticky header > body.
+
+### Mobile (run at 414×896)
+
+- [ ] Sidebar collapses or transforms appropriately.
+- [ ] Tappable targets ≥ 44px hit-area.
+- [ ] Tabular data wraps or scrolls horizontally — no clipping.
+- [ ] Pseudo-element `content` properties survive responsive breakpoints
+  (the LuCI mobile-header bug).
+
+### Interactive states (per declared state PNG)
+
+For each `<label>--<state>.png`, beyond the static checklist:
+
+- [ ] **Hover states:** background or border or fg shift is visible —
+  not subtle. The tonal→filled or +brightness progression should be
+  perceivable at a glance.
+- [ ] **Hover states:** any tooltip or popover that hover triggers
+  renders fully, isn't clipped, and respects z-index order.
+- [ ] **Focus states:** `:focus-visible` outline is on every
+  focusable element, with sufficient offset to clear native chrome.
+- [ ] **Click-to-open states:** revealed content (modal/dropdown/details
+  body) inherits the dark surfaces, not light defaults.
+- [ ] **Click-to-open states:** opener element's pressed/active state
+  is visually distinct from its rest state.
+- [ ] **Alternate viewport states:** layout reflows cleanly; no
+  overflow, clipped chrome, or missing pseudo-elements.
+- [ ] **`prefers-contrast: more`:** borders thicken / contrast lifts
+  visibly compared to default; no regression to light defaults.
+- [ ] **`prefers-reduced-motion`:** transitions stripped or shortened;
+  layout/colour identical to default state.
+- [ ] **`forced-colors: active`** (Windows high-contrast): theme yields
+  to system colors gracefully — text remains readable.
+
+If a declared state PNG is missing or fails the checklist, that is the
+single most common source of post-ship regressions. Treat as blocking.
+
+## Cache-busting (the "still on 0.1.5" problem)
+
+The user installs your script through Tampermonkey, which caches via:
+
+1. **`@updateURL` polling interval** — Tampermonkey defaults to 24h. Force
+   a check: dashboard → script → "Check for userscript updates".
+2. **GitHub raw / gist CDN** — caches `?` URLs aggressively. Bust with a
+   query string: `https://gist.../raw/dark-mode.user.js?v=3`.
+3. **The browser** caches the page itself.
+4. **The userscript manager's compiled cache** — Tampermonkey re-compiles
+   on version bump, *not* on content change.
+
+**Iteration discipline:**
+
+- Bump `@version` on **every** push. Even mid-debug. The userscript manager
+  treats same-version pushes as "no change" and does not refresh.
+- When sharing a raw URL with the user, append `?v=N` and increment N each
+  push.
+- If the user reports the script "isn't updating," ask them to:
+  1. Open Tampermonkey dashboard.
+  2. Click the script.
+  3. Check the version number visible in the editor header.
+  4. Click "Update" / "Check for updates".
+  5. Hard-reload the target page (Cmd/Ctrl-Shift-R).
+
+If they're still on the old version, paste the userscript directly into
+Tampermonkey to bypass the gist entirely while debugging.
+
+## Pre-screenshot syntax check
+
+The screenshot harness (`scripts/screenshot.py`) runs a real V8 syntax check
+before screenshotting. It is the single most valuable check because:
+
+- A backtick error inside a CSS template literal compiles to "no CSS
+  injected, screenshot looks like the unstyled fixture, you assume the
+  rules don't match."
+- Tampermonkey reports the syntax error in the user's browser console at
+  load time — but only if they install the broken script. The pre-check
+  catches it offline.
+
+If the harness errors with `userscript syntax check failed: ...`, fix
+before doing anything else. Do not screenshot a syntactically broken
+script and try to interpret the result.
+
+## Element-level contrast pass
+
+After vision review, run `scripts/contrast.py`. It walks every text node in
+each fixture, reads the computed `color` and the *effective* background
+(walking up through transparent ancestors until it hits an opaque one), and
+flags pairs below WCAG AA. Treat its output as a checklist — fix every
+flagged element.
+
+The agent-eye contrast guess is unreliable. The mechanical check is not.
+
+## What "done" looks like
+
+A fixture is "done" when:
+
+1. Light and dark screenshots both load cleanly into vision context.
+2. The dark screenshot, scanned via the per-fixture checklist above,
+   surfaces zero unaddressed items.
+3. `contrast.py` reports zero failures for the fixture.
+4. Mobile variant (if applicable) passes the same.
+
+A theme is "done" when every fixture is done **and** the user has seen the
+deployed userscript on the live site and approved.
+
+The user's "this looks much better" or equivalent is the stop condition,
+not the agent's belief. The agent's belief was wrong four times in the
+session that produced this skill.

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/scripts/contrast.py
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/scripts/contrast.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Element-level WCAG AA contrast check.
+
+For each fixture, render it with the userscript injected, walk every
+text-bearing element, read its computed `color` and the *effective*
+background (walking up through transparent ancestors until we hit an
+opaque one), and report any pair under WCAG AA (4.5:1 for normal text,
+3:1 for ≥18px or ≥14px-bold large text).
+
+This catches the failure mode where a button is "dark grey on dark page"
+— passing the page-level check while failing on itself.
+
+Usage:
+    .venv/bin/python scripts/contrast.py [fixture-glob]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_DIR = ROOT / "fixtures"
+USERSCRIPT_CANDIDATES = list(ROOT.glob("*.user.js"))
+
+
+def extract_body(text: str) -> str:
+    return re.sub(
+        r"^// ==UserScript==.*?// ==/UserScript==\n",
+        "",
+        text,
+        count=1,
+        flags=re.S,
+    )
+
+
+# JS that runs in the page: walks the DOM, computes effective bg (climbing
+# through transparent ancestors), measures contrast, returns failures.
+PROBE = r"""
+(() => {
+  function parseRGB(s) {
+    const m = s.match(/rgba?\(([^)]+)\)/);
+    if (!m) return null;
+    const parts = m[1].split(',').map(x => parseFloat(x.trim()));
+    return { r: parts[0], g: parts[1], b: parts[2], a: parts.length === 4 ? parts[3] : 1 };
+  }
+  function rel(c) {
+    c /= 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  }
+  function lum({ r, g, b }) {
+    return 0.2126 * rel(r) + 0.7152 * rel(g) + 0.0722 * rel(b);
+  }
+  function ratio(a, b) {
+    const la = lum(a), lb = lum(b);
+    const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+    return (hi + 0.05) / (lo + 0.05);
+  }
+  function effectiveBg(el) {
+    while (el) {
+      const cs = getComputedStyle(el);
+      const bg = parseRGB(cs.backgroundColor);
+      if (bg && bg.a > 0.5) return bg;
+      // also check background-image — gradient backgrounds bypass us
+      if (cs.backgroundImage && cs.backgroundImage !== 'none') {
+        return null; // can't reason about gradients here, skip
+      }
+      el = el.parentElement;
+    }
+    return { r: 255, g: 255, b: 255, a: 1 }; // fallback to UA white
+  }
+  const fails = [];
+  const all = document.querySelectorAll('*');
+  for (const el of all) {
+    // Only check elements that themselves render text
+    let hasText = false;
+    for (const node of el.childNodes) {
+      if (node.nodeType === 3 && node.nodeValue.trim()) { hasText = true; break; }
+    }
+    if (!hasText) continue;
+    const cs = getComputedStyle(el);
+    if (cs.visibility === 'hidden' || cs.display === 'none') continue;
+    if (parseFloat(cs.opacity) < 0.5) continue;
+    const fg = parseRGB(cs.color);
+    const bg = effectiveBg(el);
+    if (!fg || !bg) continue;
+    const r = ratio(fg, bg);
+    const sizePx = parseFloat(cs.fontSize);
+    const weight = parseInt(cs.fontWeight, 10) || 400;
+    const isLarge = sizePx >= 18 || (sizePx >= 14 && weight >= 700);
+    const threshold = isLarge ? 3.0 : 4.5;
+    if (r < threshold) {
+      const text = (el.innerText || '').trim().slice(0, 60);
+      fails.push({
+        tag: el.tagName.toLowerCase(),
+        cls: (el.className || '').toString().slice(0, 60),
+        text,
+        ratio: r.toFixed(2),
+        threshold,
+        size: sizePx,
+        weight,
+        fg: cs.color,
+        bg: `rgb(${bg.r},${bg.g},${bg.b})`,
+      });
+    }
+  }
+  return fails;
+})()
+"""
+
+
+def main() -> None:
+    if not USERSCRIPT_CANDIDATES:
+        sys.exit("no *.user.js found")
+    src = USERSCRIPT_CANDIDATES[0].read_text()
+    body = extract_body(src)
+    arg = sys.argv[1] if len(sys.argv) > 1 else None
+    fixtures = (
+        [Path(arg).resolve()]
+        if arg
+        else [f for f in sorted(FIXTURES_DIR.glob("*.html")) if not f.name.startswith("_")]
+    )
+
+    total_fail = 0
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        for fixture in fixtures:
+            ctx = browser.new_context(viewport={"width": 1440, "height": 900})
+            page = ctx.new_page()
+            page.add_init_script(f"""
+                window.GM_addStyle = function(css) {{
+                    const s = document.createElement('style');
+                    s.textContent = css;
+                    if (document.documentElement) {{
+                        (document.head || document.documentElement).appendChild(s);
+                    }} else {{
+                        document.addEventListener('readystatechange', () => {{
+                            (document.head || document.documentElement).appendChild(s);
+                        }}, {{ once: true }});
+                    }}
+                    return s;
+                }};
+                {body}
+            """)
+            page.goto(fixture.as_uri(), wait_until="domcontentloaded")
+            page.wait_for_timeout(250)
+            fails = page.evaluate(PROBE)
+            ctx.close()
+            if fails:
+                print(f"\n{fixture.name}: {len(fails)} contrast failures")
+                for f in fails:
+                    print(
+                        f"  {f['ratio']}:1 (need {f['threshold']:.1f}:1) "
+                        f"<{f['tag']}.{f['cls']}> "
+                        f"{f['size']:.0f}px/{f['weight']}  "
+                        f"{f['fg']} on {f['bg']}  "
+                        f"text={f['text']!r}"
+                    )
+                total_fail += len(fails)
+            else:
+                print(f"{fixture.name}: OK")
+        browser.close()
+
+    if total_fail:
+        sys.exit(f"\n{total_fail} contrast failures across {len(fixtures)} fixtures")
+    print(f"\nAll {len(fixtures)} fixtures pass WCAG AA.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/scripts/screenshot.py
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/scripts/screenshot.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+Screenshot harness for layer-theme.
+
+For each fixture under fixtures/, render it twice — once unstyled (light)
+and once with the userscript injected (dark) — and save PNGs to
+screenshots/{light,dark}/.
+
+Pre-flight: parses the userscript with V8 and aborts if syntax is broken.
+This catches stray backticks inside CSS template literals, which would
+otherwise produce a screenshot identical to the unstyled baseline and
+falsely reassure the caller that the rules don't match.
+
+Usage:
+    .venv/bin/python scripts/screenshot.py [fixture-glob]
+
+    # screenshot every fixture
+    python scripts/screenshot.py
+
+    # screenshot a single fixture
+    python scripts/screenshot.py fixtures/login.html
+
+Configuration: edit PAGES below, or define a fixtures.toml with viewport
+overrides. Default viewport is 1440x900 desktop + 414x896 mobile pair.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_DIR = ROOT / "fixtures"
+USERSCRIPT_CANDIDATES = list(ROOT.glob("*.user.js"))
+LIGHT_DIR = ROOT / "screenshots" / "light"
+DARK_DIR = ROOT / "screenshots" / "dark"
+
+DEFAULT_DESKTOP = (1440, 900)
+DEFAULT_MOBILE = (414, 896)
+
+
+def discover_pages(arg: str | None) -> list[tuple[Path, str, int, int]]:
+    """Return list of (fixture_path, label, w, h)."""
+    if arg:
+        fixtures = [Path(arg).resolve()]
+    else:
+        fixtures = sorted(FIXTURES_DIR.glob("*.html"))
+        fixtures = [f for f in fixtures if not f.name.startswith("_")]
+    out = []
+    for f in fixtures:
+        out.append((f, f.stem, *DEFAULT_DESKTOP))
+        out.append((f, f"{f.stem}-mobile", *DEFAULT_MOBILE))
+    return out
+
+
+def find_userscript() -> Path:
+    if not USERSCRIPT_CANDIDATES:
+        sys.exit("no *.user.js found in project root")
+    if len(USERSCRIPT_CANDIDATES) > 1:
+        sys.exit(f"multiple userscripts: {USERSCRIPT_CANDIDATES}; specify one")
+    return USERSCRIPT_CANDIDATES[0]
+
+
+def extract_userscript_body(text: str) -> str:
+    """Strip the metadata block; return the executable IIFE / module body."""
+    return re.sub(
+        r"^// ==UserScript==.*?// ==/UserScript==\n",
+        "",
+        text,
+        count=1,
+        flags=re.S,
+    )
+
+
+# Capture-override CSS we layer on top of everything to make full_page
+# screenshots actually capture full page height. Many themes use
+# `html { overflow-y: hidden }` and a scrolling .main container, which
+# makes Playwright's full_page mode capture only the viewport.
+CAPTURE_OVERRIDE = """
+html, body { overflow: visible !important; height: auto !important; }
+.main, [data-app-root] { position: static !important; top: 0 !important;
+                          height: auto !important; overflow: visible !important; }
+"""
+
+
+def syntax_check(page, source: str) -> None:
+    """Validate the userscript with V8 via `new Function(src)`. Throws
+    SyntaxError on bad syntax without executing the body, catching every
+    failure mode (stray backticks, unmatched parens, typos, etc.)."""
+    body = extract_userscript_body(source)
+    result = page.evaluate(
+        "(s) => { try { new Function(s); return 'OK'; } "
+        "catch (e) { return 'ERR: ' + e.message; } }",
+        body,
+    )
+    if result != "OK":
+        sys.exit(f"userscript syntax check failed: {result}")
+    print(f"  ✓ syntax check passed ({len(body)} chars)")
+
+
+def apply_state(page, state: dict) -> None:
+    """Apply one declared interactive state to the page.
+
+    A state is a dict with one of these keys, plus an optional `name`
+    used in the output filename:
+      {"hover":   "<selector>"}     # hover-pseudo
+      {"focus":   "<selector>"}     # focus-pseudo
+      {"click":   "<selector>"}     # click (open dropdown / details / modal)
+      {"viewport": {"width": N, "height": N}}
+      {"media":   [{"name": "prefers-contrast", "value": "more"}, ...]}
+                                    # CSS media features
+
+    Multiple state types can combine in one entry — a hover at mobile
+    viewport, for example.
+    """
+    if "viewport" in state:
+        v = state["viewport"]
+        page.set_viewport_size({"width": v["width"], "height": v["height"]})
+    if "media" in state:
+        page.emulate_media(features=state["media"])
+    if "click" in state:
+        page.click(state["click"])
+    if "focus" in state:
+        page.focus(state["focus"])
+    if "hover" in state:
+        page.hover(state["hover"])
+    page.wait_for_timeout(150)
+
+
+def discover_states(page) -> list[dict]:
+    """Read the fixture's declared interactive states.
+
+    Convention: a fixture may include a JSON block:
+
+        <script id="layer-theme-states" type="application/json">
+        [
+          {"name": "hover-primary", "hover": ".btn-primary"},
+          {"name": "focus-username", "focus": "#username"},
+          {"name": "details-open",   "click": "details > summary"},
+          {"name": "high-contrast",  "media": [{"name":"prefers-contrast","value":"more"}]}
+        ]
+        </script>
+
+    If absent, the static screenshot is the only render.
+    """
+    return page.evaluate("""
+        () => {
+            const tag = document.getElementById('layer-theme-states');
+            if (!tag) return [];
+            try { return JSON.parse(tag.textContent); }
+            catch (e) { return []; }
+        }
+    """)
+
+
+def make_init_script(body: str | None) -> str:
+    """Build the init script that runs at document_start: GM_addStyle
+    polyfill (if dark), the userscript body (if dark), and the
+    capture-override CSS so full_page screenshots capture full height."""
+    if body is None:
+        return f"""
+            window.addEventListener('DOMContentLoaded', () => {{
+                const s = document.createElement('style');
+                s.textContent = {CAPTURE_OVERRIDE!r};
+                document.head.appendChild(s);
+            }});
+        """
+    return f"""
+        window.GM_addStyle = function(css) {{
+            const s = document.createElement('style');
+            s.textContent = css;
+            if (document.documentElement) {{
+                (document.head || document.documentElement).appendChild(s);
+            }} else {{
+                document.addEventListener('readystatechange', () => {{
+                    (document.head || document.documentElement).appendChild(s);
+                }}, {{ once: true }});
+            }}
+            return s;
+        }};
+        {body}
+        document.addEventListener('DOMContentLoaded', () => {{
+            const s = document.createElement('style');
+            s.textContent = {CAPTURE_OVERRIDE!r};
+            document.head.appendChild(s);
+        }});
+    """
+
+
+def render(browser, fixture: Path, label: str, w: int, h: int,
+           body: str | None) -> list[Path]:
+    """Render fixture in static + every declared interactive state.
+
+    Returns the list of PNGs produced (>=1: the static base, plus one
+    per declared state).
+    """
+    ctx = browser.new_context(viewport={"width": w, "height": h})
+    page = ctx.new_page()
+    page.add_init_script(make_init_script(body))
+    page.goto(fixture.as_uri(), wait_until="domcontentloaded")
+    page.wait_for_timeout(250)  # let MutationObservers settle
+
+    out_dir = LIGHT_DIR if body is None else DARK_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    outs: list[Path] = []
+
+    base = out_dir / f"{label}.png"
+    page.screenshot(path=str(base), full_page=True)
+    outs.append(base)
+
+    states = discover_states(page)
+    for state in states:
+        sname = state.get("name") or "state"
+        # Re-load the fixture cleanly between states so they don't
+        # compose unintentionally (a focus state then a hover state on
+        # different elements would leave the focus active).
+        page = ctx.new_page()
+        page.add_init_script(make_init_script(body))
+        page.goto(fixture.as_uri(), wait_until="domcontentloaded")
+        page.wait_for_timeout(250)
+        try:
+            apply_state(page, state)
+        except Exception as e:
+            print(f"  ! state {sname!r} on {label}: {e}")
+            continue
+        out = out_dir / f"{label}--{sname}.png"
+        page.screenshot(path=str(out), full_page=True)
+        outs.append(out)
+
+    ctx.close()
+    return outs
+
+
+def main() -> None:
+    arg = sys.argv[1] if len(sys.argv) > 1 else None
+    pages = discover_pages(arg)
+    userscript = find_userscript()
+    src = userscript.read_text()
+    body = extract_userscript_body(src)
+
+    print(f"userscript: {userscript.name}")
+    print(f"fixtures:   {len({p[0] for p in pages})} files, {len(pages)} viewports")
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        check_page = browser.new_page()
+        syntax_check(check_page, src)
+        check_page.close()
+
+        for fixture, label, w, h in pages:
+            for body_arg, kind in [(None, "light"), (body, "dark ")]:
+                outs = render(browser, fixture, label, w, h, body_arg)
+                for o in outs:
+                    print(f"  {kind} {label:30s} -> {o.relative_to(ROOT)}")
+
+        browser.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/templates/critique.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/templates/critique.md
@@ -1,0 +1,99 @@
+# Critique — `<site-name>` theme
+
+Phase 3 design brief. Produced *before* writing CSS. The user reviews this
+and signs off; then implementation is mechanical.
+
+## Upstream framework
+
+- Project: `<repo / framework name>`
+- Vendored at: `theme-vendor/` (commit / version `<ref>`)
+- License: `<Apache-2.0 / MIT / GPL>`
+
+## Tier 1 — Public CSS-variable API
+
+Found `<N>` `--*` custom properties in `<file>`:
+
+| Variable | Default | Re-map to |
+|---|---|---|
+| `--upstream-bg-color` | `#fff` | `var(--t-bg)` |
+| ... | ... | ... |
+
+## Tier 2 — Hardcoded color literals
+
+Categories of selectors that need direct overrides (each row = one
+semantic group of literal colors that the upstream stylesheet bakes in
+without going through the var system):
+
+| Group | Selectors | Upstream color | Replace with |
+|---|---|---|---|
+| Page bg | `html`, `body`, `.main` | `#fff` | `var(--t-bg)` |
+| Card surface | `.card`, `.panel` | `#f6f6f6` | `var(--t-bg-2)` |
+| Table stripe | `tr:nth-child(even)` | `#f0f0f0` | `var(--t-bg-3)` |
+| Code block | `pre`, `code` | `#eee` | `var(--t-bg-code)` |
+| Border | `.card`, `input`, `table` | `#ccc`/`#ddd` | `var(--t-border)` |
+| Text grey | various | `#404040`–`#999` | `var(--t-fg)`/`--t-fg-2` |
+
+## Tier 3 — Class taxonomy
+
+Button intents:
+- `.btn-primary` → `--t-accent` fill
+- `.btn-success` → `--t-success` fill
+- `.btn-danger` → `--t-danger` fill
+- `.btn-neutral` / default → `--t-bg-2` fill, `--t-border-2` border
+
+Alert variants:
+- `.alert-info` → tonal accent surface
+- `.alert-success` → `--t-success` fill, `--t-on-success` text
+- ...
+
+Input states:
+- normal → `--t-bg-2` fill, `--t-border` outline
+- `:focus-visible` → 2px `--t-border-2` outline, offset 2px
+- `:disabled` → `--t-bg-1` fill, `--t-fg-3` text
+
+## Elevation tiers
+
+Mapping of upstream surfaces to our 5 tiers:
+
+| Surface | Upstream | Our tier |
+|---|---|---|
+| Page bg | `body` | `--t-bg` |
+| Header / sidebar / footer | `<header>`, `nav.sidebar` | `--t-bg-1` |
+| Card / panel / modal | `.card`, `.panel`, `.modal` | `--t-bg-2` |
+| Hover row, dropdown | `tr:hover`, `.dropdown-menu` | `--t-bg-3` |
+| Selected / focused row | `tr.selected` | `--t-bg-4` |
+| Code | `pre`, `code` | `--t-bg-code` |
+
+## Papercuts (light-mode bugs we'll fix while we're here)
+
+Things broken in upstream regardless of dark-mode:
+
+1. `<describe>`
+2. `<describe>`
+3. `<describe>`
+
+## Stacking-context risks
+
+Elements that contain positioned descendants (tooltip, dropdown). If we
+need to apply a visual effect (desaturation, etc.), use `color-mix` not
+`filter`:
+
+- `.zone-badge` contains `.tooltip` — no `filter`, `transform`, `opacity`,
+  `will-change`, `mix-blend-mode`, `mask`, `clip-path`, `isolation`.
+- ...
+
+## Things we are explicitly NOT changing
+
+(Set scope clearly so the reviewer knows what's out of bounds.)
+
+- `<list>`
+
+---
+
+**Reviewer:** sign off below to authorize implementation.
+
+- [ ] Tier 1 variable map looks right
+- [ ] Tier 2 selector groups complete
+- [ ] Tier 3 intents complete
+- [ ] Papercut list complete
+- [ ] Scope is right

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/templates/fixture.html
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/templates/fixture.html
@@ -1,0 +1,124 @@
+<!--
+  Fixture template — a synthetic page that links the vendored upstream CSS
+  so the screenshot rig can render against production styles.
+
+  Replace `../theme-vendor/cascade.css` with the actual vendored
+  stylesheet path. Add `<link>` tags for every stylesheet the live page
+  loads. Hand-build the body to mirror a representative production page:
+  forms, tables, buttons, alerts, modals — whatever the real page contains.
+
+  Strip dynamic JS unless the script is essential for rendering.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Fixture — replace with page name</title>
+<link rel="stylesheet" href="../theme-vendor/cascade.css">
+</head>
+<body>
+
+<!-- Header (if applicable) -->
+<header>
+  <a href="#" class="brand">App</a>
+  <nav>
+    <a href="#" class="active">Home</a>
+    <a href="#">Settings</a>
+  </nav>
+</header>
+
+<!-- Main content area -->
+<main class="container">
+  <h1>Page title</h1>
+  <p>Body copy demonstrating <a href="#">a link</a> and <strong>strong</strong>
+  and <em>emphasis</em>.</p>
+
+  <!-- Form components -->
+  <form>
+    <fieldset>
+      <legend>A form section</legend>
+      <label for="ex-text">Text input</label>
+      <input id="ex-text" type="text" value="example">
+      <label for="ex-pass">Password</label>
+      <input id="ex-pass" type="password">
+      <label><input type="checkbox" checked> A checkbox</label>
+      <label><input type="radio" name="r"> Radio A</label>
+      <label><input type="radio" name="r" checked> Radio B</label>
+      <select>
+        <option>Option 1</option>
+        <option selected>Option 2</option>
+      </select>
+    </fieldset>
+    <div class="actions">
+      <button type="submit" class="btn-primary">Save</button>
+      <button type="button" class="btn-neutral">Cancel</button>
+      <button type="button" class="btn-danger">Delete</button>
+    </div>
+  </form>
+
+  <!-- Tabular data -->
+  <table>
+    <thead>
+      <tr><th>Name</th><th>Status</th><th>Address</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>example-1</td><td><span class="pill pill-success">Up</span></td><td>192.168.1.1</td><td><button class="btn-sm">Edit</button></td></tr>
+      <tr><td>example-2</td><td><span class="pill pill-warning">Idle</span></td><td>192.168.1.2</td><td><button class="btn-sm">Edit</button></td></tr>
+      <tr><td>example-3</td><td><span class="pill pill-danger">Down</span></td><td>192.168.1.3</td><td><button class="btn-sm">Edit</button></td></tr>
+    </tbody>
+  </table>
+
+  <!-- Alerts / status messages -->
+  <div class="alert alert-info">An informational message.</div>
+  <div class="alert alert-success">An action succeeded.</div>
+  <div class="alert alert-warning">A warning to be aware of.</div>
+  <div class="alert alert-danger">An error occurred.</div>
+
+  <!-- Code block -->
+  <pre><code>example: code block
+with-multiple: lines
+to-test: monospace fg/bg</code></pre>
+
+  <!-- Details/disclosure (covers details-open state) -->
+  <details>
+    <summary>Click to expand</summary>
+    <p>Hidden content visible only when summary is clicked.</p>
+  </details>
+</main>
+
+<!--
+  Interactive-state declarations.
+
+  Each entry is a state to capture in addition to the static screenshot.
+  screenshot.py renders one PNG per entry, named
+  `<fixture>--<name>.png`. Use this for any state the static screenshot
+  doesn't cover: hover, focus, dropdown-open, modals, alternate
+  viewports, prefers-contrast / prefers-reduced-motion media features.
+
+  Available state types (one or more keys per entry):
+    {"hover":   "<selector>"}                 — hover pseudo
+    {"focus":   "<selector>"}                 — focus pseudo
+    {"click":   "<selector>"}                 — click (open dropdown/modal/details)
+    {"viewport":{"width":N,"height":N}}       — alternate viewport
+    {"media":   [{"name":"...","value":"..."}]} — CSS media features
+
+  Coverage rule of thumb: every interactive *type* in the fixture
+  (hoverable, focusable, clickable-to-open) needs at least one state
+  captured. Missing this is what let the LuCI Routing/NAT regression
+  ship.
+-->
+<script id="layer-theme-states" type="application/json">
+[
+  {"name": "hover-primary",  "hover": ".btn-primary"},
+  {"name": "hover-danger",   "hover": ".btn-danger"},
+  {"name": "focus-input",    "focus": "#ex-text"},
+  {"name": "focus-select",   "focus": "select"},
+  {"name": "details-open",   "click": "details > summary"},
+  {"name": "high-contrast",  "media": [{"name": "prefers-contrast", "value": "more"}]},
+  {"name": "reduced-motion", "media": [{"name": "prefers-reduced-motion", "value": "reduce"}]}
+]
+</script>
+
+</body>
+</html>

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/templates/regression-assessment.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/templates/regression-assessment.md
@@ -1,0 +1,142 @@
+# Regression assessment
+
+When the user reports a visual regression, **before** patching the bug
+work through this assessment. Its purpose is closing the loop — every
+regression should either propagate as durable knowledge (improved
+checklist, new fixture, sharper principle) or be classified as
+non-propagating (user preference, site corner case) and recorded
+accordingly. Patches without assessment teach nothing.
+
+The output of this template is concrete: at least one file edit
+somewhere in the skill, the project, or memory. "No change needed" is a
+valid outcome only after deliberately rejecting all four branches.
+
+## Capture
+
+- **Site / theme:**
+- **Page or fixture where it surfaced:**
+- **Interactive state, if any** (hover, focus, dropdown-open, mobile, etc.):
+- **What the user reported** (verbatim quote if possible):
+- **What the rendered output actually showed** (load the PNG; describe what
+  you see, post-vision):
+
+## Branch 1 — Could the agent reasonably have caught this visually?
+
+If the answer is "yes, this is a visible visual defect on a page the
+agent should have screenshotted," go to 1a/1b. If "no" (it's only visible
+under conditions the rig couldn't have reasonably captured, e.g. live
+network state, server-side data the user has but the agent doesn't), go
+to Branch 4 (site-specific corner case).
+
+### 1a — Did the agent load the relevant PNG into vision context?
+
+**If yes** (the screenshot was loaded but the agent didn't flag the issue):
+
+- The vision pass *missed* the defect. The agent looked but didn't see.
+- Failure mode: **vision-pattern blindness** — the principle that would
+  have flagged this defect wasn't on the per-fixture checklist.
+- **Action:** add a check to the checklist in
+  `references/vision-verification.md` § "Per-fixture checklist" that
+  would have caught this. Be specific:
+  > After the change: when reviewing `<fixture>`, verify `<element/state>`
+  > has `<expected property>` because `<failure mode this prevents>`.
+- This is the single most valuable fix: the principle is now durable
+  across all future themes.
+
+**If no** (the relevant screenshot was not loaded into context):
+
+- The vision gate was *not triggered* for this state.
+- Sub-cases:
+  - **Static state, fixture exists, screenshot wasn't read:**
+    Failure mode: agent skipped the vision gate. Strengthen the language
+    in `references/vision-verification.md` so the gate is harder to skip.
+  - **Static state, no fixture covered the page:**
+    Failure mode: fixture coverage gap. Add a fixture for this page;
+    note in `themes/<name>.md` that the original coverage was incomplete.
+  - **Interactive state (hover/focus/dropdown/mobile/media-query) not
+    captured:**
+    Failure mode: state coverage gap. Add a state spec to the fixture
+    (see `templates/fixture.html` for the `layer-theme-states` block)
+    so the next screenshot run captures it.
+
+## Branch 2 — Does the regression violate a UX principle?
+
+A principle is general — it would apply to other sites too. Examples:
+"text inside a coloured fill must use the matching `--on-*` token,"
+"properties that create stacking contexts can't be applied to elements
+containing positioned descendants."
+
+- [ ] The principle is **already** in `references/design-principles.md`
+      → why was it skipped/not applied?
+      - If a checklist item exists but the agent didn't apply it: the
+        item is ambiguous or buried — rewrite it for clarity.
+      - If the principle is documented but the agent didn't realize it
+        applied here: add a **trigger phrase** ("when you see X, recall
+        principle Y") to the design-principles entry.
+- [ ] The principle is **not** in `references/design-principles.md`
+      → add it. Concrete proposal (write it out in full):
+      ```
+      ## <heading>
+      <one-paragraph rule>
+
+      Why: <the regression that surfaced this>
+      How to apply: <when this kicks in>
+      ```
+      Cross-cite from the relevant Iron Law in `SKILL.md` if the
+      principle is severe enough to warrant gate-level enforcement.
+
+## Branch 3 — Is this user preference, not a general principle?
+
+Test: would the same change be a regression on a different site, or only
+this one and only for this user? If only this user / this site, it's
+preference, not principle.
+
+- [ ] Yes — preserve as `feedback` memory, not a principle:
+  ```
+  ---
+  name: <short>
+  description: <when this applies>
+  type: feedback
+  ---
+  Rule: <user's preference, stated as a rule>
+  Why: <reason given by the user>
+  How to apply: <when, where>
+  ```
+- Do **not** add to `design-principles.md`. That file is the public
+  contract for general theming — preferences belong in user memory,
+  scoped to this user.
+
+## Branch 4 — Is this a site-specific corner case?
+
+The defect arose because of an upstream framework quirk that doesn't
+generalize (a non-standard cascade, an outlier class taxonomy, an
+off-spec HTML structure).
+
+- [ ] Yes — record in the **theme spec** for this site, not the global
+  skill. In `themes/<style-name>.md` § "Notes / gotchas surfaced during
+  implementation," add an entry of the form:
+  > On `<framework>`: `<quirk>`. Workaround: `<fix>`.
+- Do not propagate to `design-principles.md`. The next site won't have
+  this quirk; the principle would be wrong there.
+
+## Closing the loop
+
+Before patching the bug:
+
+- [ ] Branch identified: `<1a-yes / 1a-no-static / 1a-no-state / 2-existing / 2-new / 3 / 4>`
+- [ ] Concrete change made: `<file path + line or section>`
+- [ ] If Branch 1a-no-state: state spec added to fixture.
+
+Now patch the bug. Re-run the screenshot harness, vision-verify, confirm
+the fix using the gate that was previously missing.
+
+## Recording
+
+Add a one-line entry to `themes/<style-name>.md` under "Regressions
+caught" (create the section if absent):
+
+> - 2026-MM-DD: `<one-line description>`. Branch: `<X>`. Propagated to:
+>   `<file>`.
+
+This serves as a longitudinal record of what kinds of regressions this
+theme produced and where the corresponding skill improvements landed.

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/templates/theme-spec.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/templates/theme-spec.md
@@ -1,0 +1,144 @@
+# Theme spec — `<style-name>`
+
+A site-agnostic, reusable visual style. Save as
+`themes/<style-name>.md`. Reference it on a future project by saying
+"apply the `<style-name>` style to `<site>`".
+
+## One-line aesthetic summary
+
+`<e.g.: Material dark surfaces, OpenWrt-cyan accent, three-tier weight,
+slot-based button intents, 14% tonal sidebar-active>`
+
+## Origin
+
+- First implemented for: `<site / project>`
+- Date finalized: `<YYYY-MM-DD>`
+- Reference userscript: `<URL or path>`
+
+## Palette
+
+```css
+:root {
+    /* Surfaces */
+    --t-bg:        #121417;
+    --t-bg-1:      #1a1d22;
+    --t-bg-2:      #21252b;
+    --t-bg-3:      #2d3239;
+    --t-bg-4:      #393f48;
+    --t-bg-code:   #0c0e11;
+
+    /* Text */
+    --t-fg:        #e6e8eb;
+    --t-fg-2:      #a4a9b0;
+    --t-fg-3:      #6c7178;
+    --t-fg-link:   #4ad0f4;
+
+    /* Borders / shadow */
+    --t-border:    #363b43;
+    --t-border-2:  #444a54;
+    --t-shadow:    rgba(0, 0, 0, 0.45);
+
+    /* Accent */
+    --t-accent:     #22c1f0;
+    --t-accent-2:   #4ad0f4;
+    --t-accent-dim: #155a72;
+    --t-on-accent:  #062330;
+
+    /* Status */
+    --t-success:   #5ec979;
+    --t-on-success:#0a1d10;
+    --t-warning:   #f1c453;
+    --t-on-warning:#2a1e00;
+    --t-danger:    #e57373;
+    --t-on-danger: #2a0d0d;
+}
+```
+
+## Weight tiers
+
+```css
+--t-fw-body:   400;   /* body / ambient — default cascade */
+--t-fw-medium: 500;   /* interactive: buttons, sidebar/tab active, h1–h3 */
+--t-fw-bold:   600;   /* small-text emphasis: chips, pills, labels <13px */
+```
+
+## Transition
+
+```css
+--t-trans: 150ms ease;
+```
+
+## Tonal surfaces
+
+```css
+--t-accent-tonal-bg: color-mix(in srgb, var(--t-accent) 14%, transparent);
+--t-accent-tonal-bd: color-mix(in srgb, var(--t-accent) 35%, transparent);
+```
+
+(Used for sidebar-active, alert-info, selected-row hover.)
+
+## Slot patterns
+
+Buttons:
+```css
+.btn { background: var(--btn-bg); color: var(--btn-fg);
+       border: 1px solid var(--btn-bd);
+       transition: background var(--t-trans), color var(--t-trans); }
+.btn-primary { --btn-bg: var(--t-accent);  --btn-fg: var(--t-on-accent);  --btn-bd: var(--t-accent); }
+.btn-success { --btn-bg: var(--t-success); --btn-fg: var(--t-on-success); --btn-bd: var(--t-success); }
+.btn-danger  { --btn-bg: var(--t-danger);  --btn-fg: var(--t-on-danger);  --btn-bd: var(--t-danger); }
+.btn-neutral { --btn-bg: var(--t-bg-2);    --btn-fg: var(--t-fg);         --btn-bd: var(--t-border-2); }
+```
+
+## Active sidebar / tab pattern
+
+3px accent stripe + 14% tonal bg + medium weight + primary fg.
+
+```css
+.sidebar-item.active {
+    background: var(--t-accent-tonal-bg);
+    box-shadow: inset 3px 0 var(--t-accent);
+    color: var(--t-fg);
+    font-weight: var(--t-fw-medium);
+}
+```
+
+## Focus ring
+
+```css
+:focus-visible {
+    outline: 2px solid var(--t-border-2);
+    outline-offset: 2px;
+}
+```
+
+## Native widgets
+
+```css
+:root { color-scheme: dark; accent-color: var(--t-accent); }
+::selection { background: var(--t-accent-dim); color: var(--t-fg); }
+::-webkit-scrollbar { background: var(--t-bg-1); }
+::-webkit-scrollbar-thumb { background: var(--t-border-2); border-radius: 6px; }
+```
+
+## Status semantics
+
+- Bright fill + dark on-* text (passes WCAG AA at ≥7:1).
+- Tonal versions for inline alerts (color-mix at 14%).
+
+## Notes / gotchas
+
+- `<any site-agnostic gotchas surfaced during implementation>`
+
+## Tier-1 variable mapping (site-agnostic core)
+
+Variables most frameworks expose (or should). When reusing, map upstream
+to ours:
+
+| Concept | Token |
+|---|---|
+| Page bg | `--t-bg` |
+| Surface bg | `--t-bg-2` |
+| Primary text | `--t-fg` |
+| Brand accent | `--t-accent` |
+| ... | ... |

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/templates/userscript.user.js
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/templates/userscript.user.js
@@ -1,0 +1,175 @@
+// ==UserScript==
+// @name         {{NAME}}
+// @namespace    {{NAMESPACE}}
+// @version      0.1.0
+// @description  {{DESCRIPTION}}
+// @author       {{AUTHOR}}
+// @license      {{LICENSE}}
+// @homepageURL  {{HOMEPAGE_URL}}
+// @supportURL   {{SUPPORT_URL}}
+// @updateURL    {{UPDATE_URL}}
+// @downloadURL  {{DOWNLOAD_URL}}
+// @match        http://*/path/here
+// @match        https://*/path/here
+// @run-at       document-start
+// @grant        GM_addStyle
+// ==/UserScript==
+
+(function () {
+    'use strict';
+
+    /*
+     * ============================================================
+     * ARCHITECTURE — two-tier override
+     *
+     *   Tier 1: Override the upstream public CSS-variable API.
+     *           Re-mapping these re-tones the majority of the UI.
+     *
+     *   Tier 2: Repaint the upstream stylesheet's HARDCODED color
+     *           literals — the parts that bypass its own var system.
+     *
+     *   Tier 3: Honor the framework's themeable class contract
+     *           (button/alert/input intents) using Tier-1 tokens.
+     *
+     * Edit only the :root token block below to retune the palette.
+     * Everything downstream is derived.
+     * ============================================================
+     */
+
+    const css = `
+
+:root {
+    /* --- Surfaces (5 elevation tiers + code) --- */
+    --t-bg:        #121417;
+    --t-bg-1:      #1a1d22;
+    --t-bg-2:      #21252b;
+    --t-bg-3:      #2d3239;
+    --t-bg-4:      #393f48;
+    --t-bg-code:   #0c0e11;
+
+    /* --- Text --- */
+    --t-fg:        #e6e8eb;
+    --t-fg-2:      #a4a9b0;
+    --t-fg-3:      #6c7178;
+    --t-fg-link:   #4ad0f4;
+
+    /* --- Borders / shadow --- */
+    --t-border:    #363b43;
+    --t-border-2:  #444a54;
+    --t-shadow:    rgba(0, 0, 0, 0.45);
+
+    /* --- Accent --- */
+    --t-accent:     #22c1f0;
+    --t-accent-2:   #4ad0f4;
+    --t-accent-dim: #155a72;
+    --t-on-accent:  #062330;
+
+    /* --- Status --- */
+    --t-success:   #5ec979;  --t-success-hi:#4eb869;  --t-on-success:#0a1d10;
+    --t-warning:   #f1c453;  --t-warning-hi:#e8b440;  --t-on-warning:#2a1e00;
+    --t-danger:    #e57373;  --t-danger-hi: #d96565;  --t-on-danger: #2a0d0d;
+
+    /* --- Tonal (tracks accent if customized) --- */
+    --t-accent-tonal-bg: color-mix(in srgb, var(--t-accent) 14%, transparent);
+    --t-accent-tonal-bd: color-mix(in srgb, var(--t-accent) 35%, transparent);
+
+    /* --- Weight tiers --- */
+    --t-fw-body:   400;
+    --t-fw-medium: 500;
+    --t-fw-bold:   600;
+
+    /* --- Transition --- */
+    --t-trans: 150ms ease;
+}
+
+/* ============================================================
+   TIER 1 — Override the upstream public-API color variables.
+   List the upstream framework's --vars here, mapped to --t-*.
+   ============================================================ */
+:root {
+    /* --upstream-bg-color: var(--t-bg); */
+    /* ... fill in based on Phase 3 study ... */
+}
+
+/* ============================================================
+   TIER 2 — Repaint hardcoded color literals.
+   Group selectors semantically: page bg, surfaces, borders,
+   text greys, table striping, code blocks.
+   ============================================================ */
+html, body { background-color: var(--t-bg) !important; color: var(--t-fg); }
+
+/* ... add Tier-2 selectors based on Phase 3 study ... */
+
+/* ============================================================
+   TIER 3 — Class-taxonomy intent semantics.
+   Use the slot pattern: each intent class sets --btn-bg/fg/bd.
+   ============================================================ */
+
+/* ... add Tier-3 button / alert / input rules ... */
+
+/* ============================================================
+   FOCUS RINGS, NATIVE WIDGETS, MEDIA QUERIES
+   ============================================================ */
+:focus-visible { outline: 2px solid var(--t-border-2); outline-offset: 2px; }
+:root { color-scheme: dark; accent-color: var(--t-accent); }
+::selection { background: var(--t-accent-dim); color: var(--t-fg); }
+::-webkit-scrollbar { background: var(--t-bg-1); }
+::-webkit-scrollbar-thumb { background: var(--t-border-2); border-radius: 6px; }
+
+`;
+
+    // --------------------------------------------------------------
+    // Inject. GM_addStyle is provided by Tampermonkey/Greasemonkey;
+    // we declared it in the header so the manager exposes it.
+    // --------------------------------------------------------------
+    if (typeof GM_addStyle === 'function') {
+        GM_addStyle(css);
+    } else {
+        // Fallback for raw <script> use:
+        const s = document.createElement('style');
+        s.textContent = css;
+        (document.head || document.documentElement).appendChild(s);
+    }
+
+    // --------------------------------------------------------------
+    // Optional JS: semantic-attribute tagger.
+    //
+    // Use this when the framework collapses multiple action intents
+    // under a single class — e.g. every button is `.btn-primary` and
+    // CSS attribute selectors can't reach button text. Walk every
+    // button, lift its text into data-action, then style from that.
+    // Comment out if not needed.
+    // --------------------------------------------------------------
+    /*
+    const BTN_SEL = 'button, .btn, input[type="submit"], input[type="button"]';
+    function tag(btn) {
+        if (btn.dataset.action) return;
+        const raw = (btn.value || btn.textContent || '').trim().toLowerCase();
+        if (raw) btn.dataset.action = raw.replace(/\s+/g, ' ').replace(/[…\.]+$/, '');
+    }
+    function tagAll(root) { (root || document).querySelectorAll(BTN_SEL).forEach(tag); }
+    function start() {
+        tagAll();
+        new MutationObserver(muts => {
+            for (const m of muts) {
+                for (const n of m.addedNodes) {
+                    if (n.nodeType !== 1) continue;
+                    if (n.matches && n.matches(BTN_SEL)) tag(n);
+                    if (n.querySelectorAll) tagAll(n);
+                }
+                if (m.type === 'characterData') {
+                    let p = m.target.parentElement;
+                    while (p && !p.matches(BTN_SEL)) p = p.parentElement;
+                    if (p) { delete p.dataset.action; tag(p); }
+                }
+            }
+        }).observe(document.documentElement,
+                   { childList: true, subtree: true, characterData: true });
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start, { once: true });
+    } else {
+        start();
+    }
+    */
+})();

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/themes/README.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/themes/README.md
@@ -1,0 +1,25 @@
+# Named-style catalog
+
+Each `.md` file in this directory is a finalized, named visual style that
+can be referenced by name on future projects: "apply the
+`<name>` style to `<new-site>`".
+
+A style spec is site-agnostic — palette, weight tiers, slot patterns,
+elevation tiers, focus-ring rules, native-widget harmonization. Reusing a
+style means copying the `:root` token block and the slot/active patterns,
+then doing site-specific Tier 1 + Tier 2 override work for the new target.
+
+## Catalog
+
+| Name | Origin | Aesthetic |
+|---|---|---|
+| [luci-dark-material](luci-dark-material.md) | OpenWrt LuCI | Material dark, OpenWrt cyan, 5 elevation tiers, slot buttons |
+
+## Adding a new style
+
+1. Finalize a theme on a real site.
+2. Copy `../templates/theme-spec.md` to `<style-name>.md`.
+3. Fill in palette, tiers, patterns, gotchas surfaced during implementation.
+4. Add a row to the catalog table above.
+5. Save a `reference` memory pointing at the file so future sessions can
+   find it by name.

--- a/plugins/web-ui-theming-tampermonkey/skills/layer-theme/themes/luci-dark-material.md
+++ b/plugins/web-ui-theming-tampermonkey/skills/layer-theme/themes/luci-dark-material.md
@@ -1,0 +1,240 @@
+# Theme spec — `luci-dark-material`
+
+## One-line aesthetic summary
+
+Material Design dark — five elevation tiers on near-black, OpenWrt cyan
+accent (`#22c1f0`), three-tier weight system, slot-based button intents,
+14% tonal sidebar-active. WCAG AA across the board (most pairs at 7:1+).
+
+## Origin
+
+- First implemented for: OpenWrt LuCI Material (`luci-theme-material`)
+- Date finalized: 2026-04-26
+- Reference userscript: `luci-material-dark-mode/dark-mode.user.js` v0.3.2
+- Public gist: `https://gist.github.com/stvhay/768e664951dc68fa7741d1040715fbcb`
+- License: Apache-2.0 (matching upstream LuCI theme)
+
+## Palette
+
+```css
+:root {
+    /* Surfaces — 5 elevation tiers + code */
+    --t-bg:        #121417;   /* body / page */
+    --t-bg-1:      #1a1d22;   /* sidebar, header, footer */
+    --t-bg-2:      #21252b;   /* cards, modals */
+    --t-bg-3:      #2d3239;   /* alt-row, hover, dropdown */
+    --t-bg-4:      #393f48;   /* selected row, focused dropdown */
+    --t-bg-code:   #0c0e11;   /* code blocks, syslog */
+
+    /* Text — primary ~14:1, secondary ~7.5:1, tertiary large-only */
+    --t-fg:        #e6e8eb;
+    --t-fg-2:      #a4a9b0;
+    --t-fg-3:      #6c7178;
+    --t-fg-link:   #4ad0f4;
+
+    /* Borders / shadow — visible, not ghosted */
+    --t-border:    #363b43;
+    --t-border-2:  #444a54;
+    --t-shadow:    rgba(0, 0, 0, 0.45);
+
+    /* Accent (OpenWrt brand cyan, lifted into dark) */
+    --t-accent:     #22c1f0;
+    --t-accent-2:   #4ad0f4;
+    --t-accent-dim: #155a72;
+    --t-on-accent:  #062330;   /* dark text on cyan, ~9:1 */
+
+    /* Status — dark on-* text on bright fills, ~7:1+ */
+    --t-success:   #5ec979;  --t-success-hi:#4eb869;  --t-on-success:#0a1d10;
+    --t-warning:   #f1c453;  --t-warning-hi:#e8b440;  --t-on-warning:#2a1e00;
+    --t-danger:    #e57373;  --t-danger-hi: #d96565;  --t-on-danger: #2a0d0d;
+    --t-error:     #ff6b6b;  --t-on-error:  #2a0d0d;
+
+    /* Notice — derived from accent so it tracks palette customization */
+    --t-notice:    color-mix(in srgb, var(--t-accent) 35%, var(--t-bg-2));
+    --t-on-notice: #ffffff;
+}
+```
+
+## Tonal surfaces
+
+Used for sidebar-active, alert-info, selected-row backgrounds. `color-mix`
+keeps them tracked to the accent if the user customizes the palette —
+hardcoded `rgba()` literals would not.
+
+```css
+--t-accent-tonal-bg:  color-mix(in srgb, var(--t-accent)  14%, transparent);
+--t-accent-tonal-bd:  color-mix(in srgb, var(--t-accent)  35%, transparent);
+--t-success-tonal-bg: color-mix(in srgb, var(--t-success) 14%, transparent);
+--t-success-tonal-bd: color-mix(in srgb, var(--t-success) 35%, transparent);
+--t-danger-tonal-bg:  color-mix(in srgb, var(--t-danger)  14%, transparent);
+--t-danger-tonal-bd:  color-mix(in srgb, var(--t-danger)  35%, transparent);
+```
+
+## Weight tiers
+
+```css
+--t-fw-body:   400;
+--t-fw-medium: 500;   /* buttons, sidebar/tab active, h1–h3, panel-title,
+                         table column headers, alert headings */
+--t-fw-bold:   600;   /* chips, pills, labels at <13px */
+```
+
+## Transition
+
+```css
+--t-trans: 150ms ease;
+```
+
+Applied to every interactive surface.
+
+## Slot pattern — buttons
+
+```css
+.btn {
+    background: var(--btn-bg);
+    color:      var(--btn-fg);
+    border: 1px solid var(--btn-bd);
+    font-weight: var(--t-fw-medium);
+    transition: background var(--t-trans), color var(--t-trans),
+                border-color var(--t-trans);
+}
+.btn:hover { background: var(--btn-hover, var(--btn-bg));
+             filter: brightness(1.06); }
+
+.btn-action  { --btn-bg: var(--t-accent);  --btn-fg: var(--t-on-accent);  --btn-bd: var(--t-accent);  }
+.btn-apply   { --btn-bg: var(--t-success); --btn-fg: var(--t-on-success); --btn-bd: var(--t-success); }
+.btn-remove  { --btn-bg: var(--t-danger);  --btn-fg: var(--t-on-danger);  --btn-bd: var(--t-danger);  }
+.btn-neutral { --btn-bg: var(--t-bg-2);    --btn-fg: var(--t-fg);         --btn-bd: var(--t-border-2); }
+.btn-reset   { --btn-bg: transparent;      --btn-fg: var(--t-fg-2);       --btn-bd: var(--t-border-2); }
+```
+
+Same trick scales to alerts (`.alert-success`, etc.) and badges.
+
+## Active sidebar / tab pattern
+
+The "modern Material You / Fluent" look. 3px accent stripe + 14% tonal
+background + primary fg + medium weight. Replaces upstream's solid-color
+active block (looks dated on dark).
+
+```css
+.sidebar-item.active {
+    background: var(--t-accent-tonal-bg);
+    box-shadow: inset 3px 0 var(--t-accent);
+    color: var(--t-fg);
+    font-weight: var(--t-fw-medium);
+}
+```
+
+## Hover progression
+
+- **Tonal → filled** on primary buttons (signals actionability).
+- **Brightness +6%** on filled buttons via `filter: brightness(1.06)` —
+  safe here because buttons rarely contain positioned descendants.
+- **bg-3** background on row hover and inactive sidebar/tab hover.
+- **Underline** on text links — never colour-shift.
+
+## Focus ring
+
+```css
+:focus-visible {
+    outline: 2px solid var(--t-border-2);
+    outline-offset: 2px;
+}
+```
+
+Applied to every interactive element. Even on mouse-only sites.
+
+## Native widget harmonization
+
+```css
+:root { color-scheme: dark; accent-color: var(--t-accent); }
+::selection { background: var(--t-accent-dim); color: var(--t-fg); }
+::-webkit-scrollbar { background: var(--t-bg-1); }
+::-webkit-scrollbar-thumb {
+    background: var(--t-border-2);
+    border-radius: 6px;
+}
+::-webkit-scrollbar-thumb:hover { background: var(--t-fg-3); }
+```
+
+## Status semantics
+
+- Bright fill + dark on-* text (passes WCAG AA at ≥7:1) on actual
+  status pills and filled buttons.
+- Tonal version (14% color-mix) for inline alerts — readable on dark
+  surface without shouting.
+
+## Tabular data alignment
+
+Override upstream's `text-align: center !important` on table cells. IPs,
+MACs, names, status text are unscannable when centered.
+
+```css
+table td, table th {
+    text-align: left !important;
+}
+table td.actions, table th.actions { text-align: right !important; }
+table td.icon-only { text-align: center; }      /* single-icon columns ok */
+```
+
+## Mobile pseudo-element gotcha
+
+If responsive media queries toggle `display` on a `::before`/`::after`,
+the `content` property may not survive. Restate it:
+
+```css
+@media (max-width: 600px) {
+    .header::before {
+        content: 'Menu';   /* upstream sets this only at >600px */
+        display: block;
+    }
+}
+```
+
+(Surfaced as a real upstream LuCI bug. Document in a comment when fixed.)
+
+## Notes / gotchas surfaced during implementation
+
+- **No `filter` on elements containing tooltips.** `.zone-badge` originally
+  used `filter: saturate(.7) brightness(.88)`, which created a stacking
+  context that clipped the hover tooltip. Replaced with
+  `background-color: color-mix(in srgb, var(--zone-color) 70%, var(--t-bg-2))`.
+- **Don't unscope link colour resets.** `a { color: var(--t-fg-link) }`
+  alone overrides sidebar/tab/breadcrumb link styles. Use a `:not()` chain
+  or scope to body content.
+- **Dark-on-dark icons** need `filter: invert(1) hue-rotate(180deg)` on
+  the `<img>` (sidebar caret, logout glyph in LuCI's case). Safe because
+  `<img>` rarely contains positioned descendants.
+
+## Tier-1 variable map (LuCI Material custom.css)
+
+For reference if porting to another LuCI variant. The full list is in the
+reference userscript; representative entries:
+
+| Upstream | Maps to |
+|---|---|
+| `--main-color` | `var(--t-accent)` |
+| `--secondary-color` | `var(--t-accent-2)` |
+| `--header-bg` | `var(--t-bg-1)` |
+| `--menu-bg-color` | `var(--t-bg-1)` |
+| `--submenu-bg-hover-active` | `var(--t-accent-dim)` |
+| `--green-color` | `var(--t-success)` |
+| `--on-green-color` | `var(--t-on-success)` |
+| `--red-color` | `var(--t-danger)` |
+| `--white-color` | `var(--t-bg-2)` |
+| `--black-color` | `var(--t-fg)` |
+
+## Reuse
+
+To apply this style to another site:
+
+1. Read this file as the design spec.
+2. Copy the `:root` block above into the target's userscript.
+3. Identify the target framework's public-API vars; map them to
+   `--t-*` (Tier 1).
+4. Find hardcoded literals; override them in semantic groups (Tier 2).
+5. Apply the slot pattern, sidebar/tab pattern, focus ring, native-widget
+   harmonization verbatim — these are framework-agnostic.
+
+The palette + weight tiers + slot patterns transfer cleanly. Tier 2 work
+is always site-specific.


### PR DESCRIPTION
## Summary

Surgical incorporation of a draft theming plugin distilled from a single-day OpenWrt LuCI dark-mode userscript exercise (April 2026).

- Renames `plugins/web-ui-theming/` → `plugins/web-ui-theming-tampermonkey/`. Reserves the `web-ui-theming-*` namespace for future delivery-target siblings (e.g. Stylus-only, browser-extension) without committing to building any now.
- Adds the plugin's `skills/SPEC.md` (5 invariants pulled from the SKILL.md Iron Laws + 6 failure modes) and a plugin-level `DESIGN.md` (load-bearing design intent — Vision-API > analytical-reasoning, generality-as-quality-metric, vendor-real-CSS, etc., extracted from the removed `TURNOVER.md`).
- Registers in `.claude-plugin/marketplace.json` and the top-level `README.md` plugins table.
- **No skill-content changes** — `SKILL.md`, `references/`, `scripts/`, `templates/`, and `themes/` carry over byte-identical from the originating session.

## Test plan

- [x] `dev-workflow-toolkit` pytest suite: 358 passed / 2 skipped / 0 failed
- [x] `quality-gate.sh`: all 95 checks passed
- [x] Description string byte-identical across `plugin.json`, `marketplace.json`, and `README.md` (verified via `diff`)
- [x] `vsa-coverage` and `doc-structure` pass for the new `skills/SPEC.md`
- [x] `inv-numbering` passes (INV-1..INV-5, FAIL-1..FAIL-6 sequential)
- [ ] Post-merge: `/plugin install web-ui-theming-tampermonkey@my-claude-plugins` resolves
- [ ] Post-merge: smoke-test `layer-theme` skill activation per `TURNOVER.md` § "Smoke test" (testing instructions captured in DESIGN.md / SKILL.md)

## Follow-ups (not in scope)

- Pre-existing inconsistency on `main`: `plugins/dev-workflow-toolkit/pyproject.toml` is at `1.21.0` but `uv.lock` still records `1.20.0`. The version-bumper bot updates `pyproject.toml` only. Worth a separate fix to teach the bot to also regenerate `uv.lock`.
- Memory entries in the originating LuCI project (`~/.claude/projects/-workspace-luci-material-dark-mode/memory/`) reference the old staging path; they'll become stale after this merge. Local-only, user can update at convenience.

<details><summary>Implementation Plan</summary>

Plan: `~/.claude/plans/2026-04-28-web-ui-theming-tampermonkey-plan.md`
Design: `~/.claude/plans/2026-04-28-web-ui-theming-tampermonkey-design.md`

Two tasks executed via subagent-driven-development with two-stage review per task plus a final cross-task review:
- **Task 1** — rename + plugin-internal updates (commit `ca14ab9`); polish commit `5857881` resolved 5 reviewer findings (false Pillow dep, README stale title/path, INV-1 enforcement overclaim, internal scripts in Public Interface table, CHANGELOG bullet split).
- **Task 2** — external registration + verification (commit `084cd4f`).
- Final commit `7562578` — restructured CHANGELOG so version-check finds the required `## Unreleased` section.

</details>

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)